### PR TITLE
Adopt SwiftFormat: scoped gate, then one whole-tree pass

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,9 @@
+# Commits that are pure mechanical reformatting. `git blame` skips these so it
+# still points at whoever last wrote the line, not at the formatter.
+#
+# Enable locally with:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+# GitHub reads this file automatically.
+
+# Format the tree with SwiftFormat (step 2 of the SwiftFormat adoption)
+d2fd50af4ff9476bcd6ce02dc92655881e2404f3

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -4,6 +4,13 @@
 # Enable locally with:
 #   git config blame.ignoreRevsFile .git-blame-ignore-revs
 # GitHub reads this file automatically.
+#
+# Entries must be full 40-character SHAs of commits that exist on master. That
+# makes the merge method load-bearing: squash and rebase both rewrite a branch
+# into new commits, so a SHA recorded on the branch would name a commit master
+# never receives and the entry would silently do nothing. Merge a branch that
+# adds an entry here with a real merge commit, which is what this repository
+# already does, or record the post-merge SHA in a follow-up commit instead.
 
 # Format the tree with SwiftFormat (step 2 of the SwiftFormat adoption)
 d2fd50af4ff9476bcd6ce02dc92655881e2404f3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,9 +81,13 @@ jobs:
       # commit will format the remainder later. See docs/DEVELOPMENT.md.
       - name: SwiftFormat gate (files this change touches)
         env:
-          # Push events: the commit the branch was on before this push. Empty on
-          # pull_request, where the script uses the base branch instead.
-          SWIFTFORMAT_LINT_BASE: ${{ github.event.before }}
+          # Push events only: the commit the branch was on before this push.
+          # Deliberately blank everywhere else so the script falls through to the
+          # pull request's base branch. `github.event.before` is empty when a PR
+          # is opened but carries the *previous head* on every later synchronize,
+          # so passing it unconditionally silently narrowed the gate to the last
+          # push's delta instead of everything the PR changes.
+          SWIFTFORMAT_LINT_BASE: ${{ github.event_name == 'push' && github.event.before || '' }}
         run: script/swiftformat_lint.sh
 
       # Never fails. This is the burn-down number for the step-2 commit, printed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,14 @@ env:
   # version is no longer installed on the image.
   XCODE_VERSION: "26.5"
 
+  # A formatter is only a gate if CI and every workstation run the same build:
+  # a different version reformats different lines and the two disagree about
+  # what "formatted" means. This must match the --minversion line in
+  # .swiftformat, which the install step asserts. The checksum is for that
+  # release's swiftformat_linux.zip, so bump both in the same commit.
+  SWIFTFORMAT_VERSION: "0.62.1"
+  SWIFTFORMAT_LINUX_SHA256: "61ff55f3581e2144a4ad114831167102c38be853df75c1477d20b40a8e8120aa"
+
 jobs:
   hygiene:
     name: Repo hygiene
@@ -46,6 +54,43 @@ jobs:
 
       - name: Translation gate fixtures
         run: script/test_localization_new_key_gate.sh
+
+      # The release ships a fully static Linux binary (built against the static
+      # Swift SDK), so no Swift toolchain is needed on this runner and the whole
+      # step is a download plus a checksum.
+      - name: Install SwiftFormat
+        run: |
+          set -euo pipefail
+          pinned="$(sed -n 's/^--minversion[[:space:]]\{1,\}//p' .swiftformat | tr -d '[:space:]')"
+          if [ "$pinned" != "$SWIFTFORMAT_VERSION" ]; then
+            echo "::error file=.swiftformat::.swiftformat pins SwiftFormat $pinned but this workflow installs $SWIFTFORMAT_VERSION; the two must be bumped together."
+            exit 1
+          fi
+          zip="$RUNNER_TEMP/swiftformat_linux.zip"
+          curl -fsSL --retry 3 -o "$zip" \
+            "https://github.com/nicklockwood/SwiftFormat/releases/download/${SWIFTFORMAT_VERSION}/swiftformat_linux.zip"
+          echo "${SWIFTFORMAT_LINUX_SHA256}  ${zip}" | sha256sum -c -
+          unzip -q "$zip" -d "$RUNNER_TEMP/swiftformat"
+          chmod +x "$RUNNER_TEMP/swiftformat/swiftformat_linux"
+          echo "SWIFTFORMAT=$RUNNER_TEMP/swiftformat/swiftformat_linux" >> "$GITHUB_ENV"
+          "$RUNNER_TEMP/swiftformat/swiftformat_linux" --version
+
+      # Only the files this change touches. The tree was written for years
+      # without a formatter, so a repo-wide gate would be red on arrival; the
+      # scoped gate converges the tree as it is edited, and one mechanical
+      # commit will format the remainder later. See docs/DEVELOPMENT.md.
+      - name: SwiftFormat gate (files this change touches)
+        env:
+          # Push events: the commit the branch was on before this push. Empty on
+          # pull_request, where the script uses the base branch instead.
+          SWIFTFORMAT_LINT_BASE: ${{ github.event.before }}
+        run: script/swiftformat_lint.sh
+
+      # Never fails. This is the burn-down number for the step-2 commit, printed
+      # where it can be watched rather than re-derived by hand.
+      - name: SwiftFormat debt in the rest of the tree
+        if: always()
+        run: script/swiftformat_lint.sh --all --summary || true
 
       - name: Shell scripts are executable and have a shebang
         run: |

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,114 @@
+# SwiftFormat configuration for ClashMax.
+#
+# Rollout is deliberately two-step (see docs/DEVELOPMENT.md):
+#   1. this file + a CI gate that only lints files a change already touches;
+#   2. one separate, mechanical "format the whole tree" commit later.
+# So a large residual violation count in untouched files is expected for now.
+#
+# Every option below was measured against the tree, not guessed: the settings
+# describe the style the codebase already uses, so adopting the formatter is a
+# normalization pass rather than a restyle.
+#
+# Run `script/swiftformat_lint.sh --help` for the local workflow.
+
+# Pinned so a stale local binary cannot disagree with CI about what is legal.
+# script/swiftformat_lint.sh parses this line; CI installs exactly this version.
+--minversion 0.62.1
+
+# Matches SWIFT_VERSION in project.yml. Keeps SwiftFormat from applying
+# rewrites that need a newer language mode than the project builds with.
+--swiftversion 6.0
+
+
+# MARK: - House style (measured against the existing tree)
+
+# 2 spaces. Measured: 298 offending lines at --indent 2 vs 86,990 at --indent 4.
+--indent 2
+
+# `0..<count`, `1...65_535`. Measured: 361 unspaced vs 19 spaced.
+--ranges no-space
+
+# `0xc0`, not `0xC0`. Measured: 32 lowercase vs 10 uppercase.
+--hex-literal-case lowercase
+
+# Digit grouping is a readability decision the author already made
+# (`16_384`, `65_535`); the default thresholds would strip those underscores.
+--decimal-grouping ignore
+--hex-grouping ignore
+--binary-grouping ignore
+--octal-grouping ignore
+
+# os.Logger builds its message from @escaping autoclosures, so a property
+# referenced inside `\(...)` is captured in an escaping closure and Swift
+# requires the explicit `self.`. SwiftFormat does not model that and stripped it,
+# which broke the ClashMaxNetworkExtension build. Naming the log methods here is
+# what keeps `redundantSelf` from producing code that does not compile.
+--self-required log,trace,debug,info,notice,warning,error,critical,fault
+
+# Only rename unused *closure* parameters to `_`. Renaming an unused function
+# parameter to `bar _: Int` deletes the name that documented the call site,
+# which matters for protocol conformances and delegate methods.
+--strip-unused-args closure-only
+
+# No --max-width on purpose: re-wrapping long lines is the single largest and
+# least reviewable diff a formatter can produce, and line length here is
+# already sane (p99 = 114 columns).
+
+
+# MARK: - Disabled rules
+#
+# The dividing line: the formatter normalizes mechanical syntax (whitespace,
+# indentation, ordering, redundant tokens, trailing commas). It does not
+# restructure or delete code a human wrote deliberately — that belongs in code
+# review, where someone can judge intent.
+
+# Wrapping single-line bodies. `var id: String { rawValue }` and
+# `if index != nil { isDiscarding = false }` are deliberate and idiomatic;
+# expanding them adds ~630 lines of pure noise across the tree.
+--disable wrapPropertyBodies
+--disable wrapIfStatementBodies
+--disable wrapIfExpressionBodies
+--disable wrapFunctionBodies
+--disable wrapLoopBodies
+
+# Rewrites `var x: T; if … { x = a } else { x = b }` into
+# `var x: T = if … { a } else { b }`. Restructures control flow, and the result
+# reads worse for the multi-branch `if let` chains this codebase uses.
+--disable conditionalAssignment
+
+# Promotes an explanatory `//` above a declaration to `///`, which changes what
+# Quick Help shows. Implementation rationale is not API documentation, and this
+# codebase writes a lot of the former.
+--disable docComments
+
+# Deletes hand-written memberwise initializers. Code deletion, not formatting.
+--disable redundantMemberwiseInit
+
+# Removing a SwiftUI `Group` changes ViewBuilder view identity, which can change
+# animation and @State behavior. Not a formatting concern.
+--disable redundantSwiftUIGroup
+
+# Rewrites `!` / `try!` in tests into XCTUnwrap-shaped code. That is a test
+# authoring decision (187 sites), not whitespace.
+--disable noForceUnwrapInTests
+--disable noForceTryInTests
+
+# Strips `throws` / `async` from a declaration that no longer needs it. That is
+# an API change, not a formatting one: 53 of the 55 sites here are XCTest
+# methods, where `throws` is deliberate headroom so the next `try XCTUnwrap`
+# does not have to touch the signature.
+--disable redundantThrows
+--disable redundantAsync
+
+# Rewrites `<T: Encodable>` into `some Encodable`. Also a declaration change,
+# and it degrades where the parameter had no constraint to speak of --
+# `<T>` becomes `some Any`.
+--disable opaqueGenericParameters
+
+
+# MARK: - Excluded paths
+
+# DerivedData* holds the checked-out SPM dependencies (Sparkle, Yams, Pow, …):
+# ~170 Swift files that are not ours. Only these directories contain Swift at
+# all, so the list stays short on purpose.
+--exclude DerivedData*,.build,.worktrees

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,12 +28,18 @@ Open the generated `ClashMax.xcodeproj`, or run the main verification command:
 xcodebuild test -project ClashMax.xcodeproj -scheme ClashMax -destination 'platform=macOS' -derivedDataPath DerivedData CODE_SIGNING_ALLOWED=NO
 ```
 
-Formatting is enforced by SwiftFormat, pinned to the version in `.swiftformat`:
+Formatting is enforced by SwiftFormat, pinned to the exact version in
+`.swiftformat`:
 
 ```bash
 brew install swiftformat
 script/swiftformat_lint.sh --fix
 ```
+
+A newer SwiftFormat is rejected as well as an older one, because new releases
+enable new rules by default and would produce a diff CI does not accept. If
+Homebrew has moved past the pin, the script's error message links the release to
+install instead.
 
 CI checks only the files your change touches, so a file you did not open is
 allowed to be unformatted for now — the tree is being formatted incrementally.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,18 @@ Open the generated `ClashMax.xcodeproj`, or run the main verification command:
 xcodebuild test -project ClashMax.xcodeproj -scheme ClashMax -destination 'platform=macOS' -derivedDataPath DerivedData CODE_SIGNING_ALLOWED=NO
 ```
 
+Formatting is enforced by SwiftFormat, pinned to the version in `.swiftformat`:
+
+```bash
+brew install swiftformat
+script/swiftformat_lint.sh --fix
+```
+
+CI checks only the files your change touches, so a file you did not open is
+allowed to be unformatted for now — the tree is being formatted incrementally.
+If `--fix` produces more churn than your change, that file simply had never been
+formatted; keep it as its own commit so the review stays readable.
+
 Run the localization gate before release, and whenever a change touches
 user-visible strings:
 
@@ -67,6 +79,7 @@ Before opening a PR, please confirm:
 - The PR explains the problem, the user-visible behavior, and the chosen fix.
 - Relevant screenshots or screen recordings are included for visible UI changes.
 - The narrowest useful verification command was run, and the result is included in the PR.
+- `script/swiftformat_lint.sh` passes for the files the change touches.
 - `script/localization_gate.sh` was run when the PR touches user-visible strings or release preparation.
 - New user-visible strings have a `zh-Hans` translation in `Resources/Localizable.xcstrings`; `script/localization_new_key_gate.sh` passes. Growing `script/localization_untranslated_allowlist.txt` needs a reason in the PR.
 - Documentation was updated when behavior, installation, release, or security expectations changed.

--- a/ClashMax/App/ClashMaxApp.swift
+++ b/ClashMax/App/ClashMaxApp.swift
@@ -198,7 +198,7 @@ private struct MenuBarStatusLabel: View {
 
   init(appModel: AppModel) {
     self.appModel = appModel
-    self.runtimeData = appModel.runtimeData
+    runtimeData = appModel.runtimeData
   }
 
   var body: some View {
@@ -423,9 +423,9 @@ enum AppActivationPolicyResolver {
 enum LaunchAtLoginRepairLaunchGate {
   static var shouldRun: Bool {
     #if DEBUG
-    false
+      false
     #else
-    true
+      true
     #endif
   }
 }
@@ -485,7 +485,7 @@ enum AppLaunchWarmupPolicy {
 
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
-  private static weak var sharedDelegate: AppDelegate?
+  private weak static var sharedDelegate: AppDelegate?
 
   weak var appModel: AppModel?
   private var terminationCleanupInFlight = false
@@ -535,7 +535,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
       // app windows so the status item's own window is never ordered out.
       DispatchQueue.main.async {
         for window in NSApp.windows
-        where AppActivationPolicyWindowSnapshot(window: window).isRegularAppWindow {
+          where AppActivationPolicyWindowSnapshot(window: window).isRegularAppWindow
+        {
           window.orderOut(nil)
         }
         Self.refreshActivationPolicyForCurrentWindows()
@@ -640,7 +641,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     NSApp.setActivationPolicy(.regular)
     NSApp.unhide(nil)
     for window in NSApp.windows
-    where AppActivationPolicyWindowSnapshot(window: window).isRegularAppWindow {
+      where AppActivationPolicyWindowSnapshot(window: window).isRegularAppWindow
+    {
       if window.isMiniaturized {
         window.deminiaturize(nil)
       }

--- a/ClashMax/App/ClashMaxAppIntents.swift
+++ b/ClashMax/App/ClashMaxAppIntents.swift
@@ -86,7 +86,7 @@ struct ClashMaxAppShortcuts: AppShortcutsProvider {
       intent: StartClashMaxIntent(),
       phrases: [
         "Start \(.applicationName)",
-        "Start proxy in \(.applicationName)"
+        "Start proxy in \(.applicationName)",
       ],
       shortTitle: "Start",
       systemImageName: "play.fill"
@@ -95,7 +95,7 @@ struct ClashMaxAppShortcuts: AppShortcutsProvider {
       intent: StopClashMaxIntent(),
       phrases: [
         "Stop \(.applicationName)",
-        "Stop proxy in \(.applicationName)"
+        "Stop proxy in \(.applicationName)",
       ],
       shortTitle: "Stop",
       systemImageName: "stop.fill"
@@ -104,7 +104,7 @@ struct ClashMaxAppShortcuts: AppShortcutsProvider {
       intent: RestartClashMaxIntent(),
       phrases: [
         "Restart \(.applicationName)",
-        "Restart proxy in \(.applicationName)"
+        "Restart proxy in \(.applicationName)",
       ],
       shortTitle: "Restart",
       systemImageName: "arrow.clockwise"
@@ -113,7 +113,7 @@ struct ClashMaxAppShortcuts: AppShortcutsProvider {
       intent: ToggleSystemProxyIntent(),
       phrases: [
         "Toggle system proxy in \(.applicationName)",
-        "Switch system proxy in \(.applicationName)"
+        "Switch system proxy in \(.applicationName)",
       ],
       shortTitle: "System Proxy",
       systemImageName: "network.badge.shield.half.filled"
@@ -122,7 +122,7 @@ struct ClashMaxAppShortcuts: AppShortcutsProvider {
       intent: UpdateClashMaxSubscriptionsIntent(),
       phrases: [
         "Update subscriptions in \(.applicationName)",
-        "Refresh subscriptions in \(.applicationName)"
+        "Refresh subscriptions in \(.applicationName)",
       ],
       shortTitle: "Update Subs",
       systemImageName: "arrow.triangle.2.circlepath"
@@ -131,7 +131,7 @@ struct ClashMaxAppShortcuts: AppShortcutsProvider {
       intent: ApplyClashMaxNetworkPolicyIntent(),
       phrases: [
         "Apply network policy in \(.applicationName)",
-        "Use current network policy in \(.applicationName)"
+        "Use current network policy in \(.applicationName)",
       ],
       shortTitle: "Network Policy",
       systemImageName: "wifi.router"

--- a/ClashMax/Models/BackupModels.swift
+++ b/ClashMax/Models/BackupModels.swift
@@ -79,23 +79,23 @@ struct ClashMaxBackupFile: Codable, Equatable, Sendable {
         forKey: .outboundProxyManifest
       ) ?? OutboundProxyEndpointManifest()
     }
-    self.init(
+    try self.init(
       schemaVersion: schemaVersion,
-      appMetadata: try container.decode(BackupAppMetadata.self, forKey: .appMetadata),
-      profilesManifest: try container.decode(ProfileManifest.self, forKey: .profilesManifest),
+      appMetadata: container.decode(BackupAppMetadata.self, forKey: .appMetadata),
+      profilesManifest: container.decode(ProfileManifest.self, forKey: .profilesManifest),
       outboundProxyManifest: outboundProxyManifest,
-      profileSources: try container.decode([BackupProfileSource].self, forKey: .profileSources),
-      settings: try container.decode(BackupSettingsSnapshot.self, forKey: .settings),
-      proxySelections: try container.decode([String: [String: String]].self, forKey: .proxySelections),
-      runtimeSnippets: try container.decodeIfPresent([RuntimeSnippet].self, forKey: .runtimeSnippets),
-      omittedSecretSummary: try container.decodeIfPresent(BackupSecretSummary.self, forKey: .omittedSecretSummary)
+      profileSources: container.decode([BackupProfileSource].self, forKey: .profileSources),
+      settings: container.decode(BackupSettingsSnapshot.self, forKey: .settings),
+      proxySelections: container.decode([String: [String: String]].self, forKey: .proxySelections),
+      runtimeSnippets: container.decodeIfPresent([RuntimeSnippet].self, forKey: .runtimeSnippets),
+      omittedSecretSummary: container.decodeIfPresent(BackupSecretSummary.self, forKey: .omittedSecretSummary)
         ?? BackupSecretSummary(),
-      encryptedSecrets: try container.decodeIfPresent(BackupEncryptedSecrets.self, forKey: .encryptedSecrets),
-      encryptedProfileSources: try container.decodeIfPresent(
+      encryptedSecrets: container.decodeIfPresent(BackupEncryptedSecrets.self, forKey: .encryptedSecrets),
+      encryptedProfileSources: container.decodeIfPresent(
         BackupEncryptedProfileSources.self,
         forKey: .encryptedProfileSources
       ),
-      encryptedRuntimeSnippets: try container.decodeIfPresent(
+      encryptedRuntimeSnippets: container.decodeIfPresent(
         BackupEncryptedRuntimeSnippets.self,
         forKey: .encryptedRuntimeSnippets
       )
@@ -164,13 +164,13 @@ struct BackupSecretSummary: Codable, Equatable, Sendable {
 
   init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
-    self.init(
-      subscriptionURLCount: try container.decodeIfPresent(Int.self, forKey: .subscriptionURLCount) ?? 0,
-      requestHeaderValueCount: try container.decodeIfPresent(Int.self, forKey: .requestHeaderValueCount) ?? 0,
-      runtimeMergeYAMLCount: try container.decodeIfPresent(Int.self, forKey: .runtimeMergeYAMLCount) ?? 0,
-      profileSourceCredentialCount: try container.decodeIfPresent(Int.self, forKey: .profileSourceCredentialCount) ?? 0,
-      runtimeSnippetCount: try container.decodeIfPresent(Int.self, forKey: .runtimeSnippetCount) ?? 0,
-      outboundProxyPasswordCount: try container.decodeIfPresent(
+    try self.init(
+      subscriptionURLCount: container.decodeIfPresent(Int.self, forKey: .subscriptionURLCount) ?? 0,
+      requestHeaderValueCount: container.decodeIfPresent(Int.self, forKey: .requestHeaderValueCount) ?? 0,
+      runtimeMergeYAMLCount: container.decodeIfPresent(Int.self, forKey: .runtimeMergeYAMLCount) ?? 0,
+      profileSourceCredentialCount: container.decodeIfPresent(Int.self, forKey: .profileSourceCredentialCount) ?? 0,
+      runtimeSnippetCount: container.decodeIfPresent(Int.self, forKey: .runtimeSnippetCount) ?? 0,
+      outboundProxyPasswordCount: container.decodeIfPresent(
         Int.self,
         forKey: .outboundProxyPasswordCount
       ) ?? 0
@@ -206,9 +206,9 @@ struct BackupSecretsBundle: Codable, Equatable, Sendable {
 
   init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
-    self.init(
-      subscriptions: try container.decode([BackupSubscriptionSecrets].self, forKey: .subscriptions),
-      outboundProxyPasswords: try container.decodeIfPresent(
+    try self.init(
+      subscriptions: container.decode([BackupSubscriptionSecrets].self, forKey: .subscriptions),
+      outboundProxyPasswords: container.decodeIfPresent(
         [BackupOutboundProxyEndpointPassword].self,
         forKey: .outboundProxyPasswords
       ) ?? []
@@ -350,35 +350,35 @@ struct BackupSettingsSnapshot: Codable, Equatable, Sendable {
 
   init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
-    self.init(
-      runtimeSettings: try container.decode(PersistedRuntimeSettings.self, forKey: .runtimeSettings),
-      proxyRoutingMode: try container.decode(ProxyRoutingMode.self, forKey: .proxyRoutingMode),
-      systemProxySettings: try container.decode(SystemProxySettings.self, forKey: .systemProxySettings),
-      ipv6Enabled: try container.decode(Bool.self, forKey: .ipv6Enabled),
-      tunSettings: try container.decode(TunSettings.self, forKey: .tunSettings),
-      networkExtensionRoutingSettings: try container.decode(
+    try self.init(
+      runtimeSettings: container.decode(PersistedRuntimeSettings.self, forKey: .runtimeSettings),
+      proxyRoutingMode: container.decode(ProxyRoutingMode.self, forKey: .proxyRoutingMode),
+      systemProxySettings: container.decode(SystemProxySettings.self, forKey: .systemProxySettings),
+      ipv6Enabled: container.decode(Bool.self, forKey: .ipv6Enabled),
+      tunSettings: container.decode(TunSettings.self, forKey: .tunSettings),
+      networkExtensionRoutingSettings: container.decode(
         NetworkExtensionRoutingSettings.self,
         forKey: .networkExtensionRoutingSettings
       ),
-      ruleOverlaySettings: try container.decode(RuleOverlaySettings.self, forKey: .ruleOverlaySettings),
-      delayTestSettings: try container.decode(DelayTestSettings.self, forKey: .delayTestSettings),
-      subscriptionFetchSettings: try container.decode(
+      ruleOverlaySettings: container.decode(RuleOverlaySettings.self, forKey: .ruleOverlaySettings),
+      delayTestSettings: container.decode(DelayTestSettings.self, forKey: .delayTestSettings),
+      subscriptionFetchSettings: container.decode(
         SubscriptionFetchSettings.self,
         forKey: .subscriptionFetchSettings
       ),
-      menuBarPinnedGroupSettings: try container.decode(
+      menuBarPinnedGroupSettings: container.decode(
         MenuBarPinnedGroupSettings.self,
         forKey: .menuBarPinnedGroupSettings
       ),
-      proxyPageSettings: try container.decodeIfPresent(ProxyPageSettings.self, forKey: .proxyPageSettings) ?? .default,
-      globalShortcutSettings: try container.decode(GlobalShortcutSettings.self, forKey: .globalShortcutSettings),
-      externalDashboardProfiles: try container.decode(
+      proxyPageSettings: container.decodeIfPresent(ProxyPageSettings.self, forKey: .proxyPageSettings) ?? .default,
+      globalShortcutSettings: container.decode(GlobalShortcutSettings.self, forKey: .globalShortcutSettings),
+      externalDashboardProfiles: container.decode(
         [ExternalDashboardProfile].self,
         forKey: .externalDashboardProfiles
       ),
-      networkPolicySettings: try container.decode(NetworkPolicySettings.self, forKey: .networkPolicySettings),
-      appTheme: try container.decode(AppTheme.self, forKey: .appTheme),
-      externalControllerSettings: try container.decode(
+      networkPolicySettings: container.decode(NetworkPolicySettings.self, forKey: .networkPolicySettings),
+      appTheme: container.decode(AppTheme.self, forKey: .appTheme),
+      externalControllerSettings: container.decode(
         BackupExternalControllerSettings.self,
         forKey: .externalControllerSettings
       )

--- a/ClashMax/Models/CoreModels.swift
+++ b/ClashMax/Models/CoreModels.swift
@@ -189,11 +189,11 @@ enum ProfileSource: Codable, Equatable, Sendable {
     let kind = try container.decode(String.self, forKey: .kind)
     switch kind {
     case "localFile":
-      self = .localFile(originalPath: try container.decodeIfPresent(String.self, forKey: .originalPath))
+      self = try .localFile(originalPath: container.decodeIfPresent(String.self, forKey: .originalPath))
     case "subscription":
-      self = .subscription(id: try container.decode(UUID.self, forKey: .subscriptionID))
+      self = try .subscription(id: container.decode(UUID.self, forKey: .subscriptionID))
     case "manualProxy":
-      self = .manualProxy(endpointID: try container.decode(UUID.self, forKey: .endpointID))
+      self = try .manualProxy(endpointID: container.decode(UUID.self, forKey: .endpointID))
     default:
       throw DecodingError.dataCorruptedError(forKey: .kind, in: container, debugDescription: "Unknown profile source")
     }
@@ -597,7 +597,7 @@ struct SubscriptionProviderOptionsGuardrailReport: Codable, Equatable, Sendable 
         options.generatedTemplate.presetSummary,
         options.generatedTemplate.ruleSummary,
         options.generatedTemplate.versionSummary(version: options.generatedTemplateVersion),
-        options.generatedTemplate.dnsSummary
+        options.generatedTemplate.dnsSummary,
       ],
       rollbackAvailable: rollbackOptions.map { $0 != options } ?? false
     )
@@ -758,7 +758,7 @@ struct SubscriptionProviderOptionsGuardrailReport: Codable, Equatable, Sendable 
             key: source,
             severity: .warning,
             message: String(localized: "YAML must be a mapping to be applied safely.")
-          )
+          ),
         ]
       }
       var risks: [ProviderOptionsRisk] = []
@@ -772,7 +772,7 @@ struct SubscriptionProviderOptionsGuardrailReport: Codable, Equatable, Sendable 
           key: source,
           severity: .danger,
           message: String(format: String(localized: "YAML parse failed: %@"), String(describing: error))
-        )
+        ),
       ]
     }
   }
@@ -802,7 +802,7 @@ struct SubscriptionProviderOptionsGuardrailReport: Codable, Equatable, Sendable 
 
   private static func risk(for key: String, path: [String], source: String) -> ProviderOptionsRisk? {
     let normalizedKey = key.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-    let dangerKeys: Set<String> = [
+    let dangerKeys: Set = [
       "external-controller",
       "external-controller-cors",
       "secret",
@@ -816,7 +816,7 @@ struct SubscriptionProviderOptionsGuardrailReport: Codable, Equatable, Sendable 
       "tun",
       "dns",
       "script",
-      "listeners"
+      "listeners",
     ]
     guard dangerKeys.contains(normalizedKey) || normalizedKey.hasSuffix("-port") else { return nil }
     let severity: ProviderOptionsRisk.Severity = ["secret", "external-controller", "listeners", "script"].contains(normalizedKey)
@@ -992,13 +992,13 @@ struct SubscriptionUpdatePolicy: Codable, Equatable, Sendable {
   init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let defaults = Self.default
-    self.init(
+    try self.init(
       automaticUpdatesEnabled: container.decodeDefault(
         Bool.self,
         forKey: .automaticUpdatesEnabled,
         default: defaults.automaticUpdatesEnabled
       ),
-      intervalOverrideMinutes: try container.decodeIfPresent(Int.self, forKey: .intervalOverrideMinutes),
+      intervalOverrideMinutes: container.decodeIfPresent(Int.self, forKey: .intervalOverrideMinutes),
       prefersRemoteInterval: container.decodeDefault(
         Bool.self,
         forKey: .prefersRemoteInterval,
@@ -1089,14 +1089,14 @@ struct SubscriptionUpdateStatus: Codable, Equatable, Sendable {
 
   init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
-    self.init(
+    try self.init(
       result: container.decodeDefault(SubscriptionUpdateResult.self, forKey: .result, default: .never),
-      lastStartedAt: try container.decodeIfPresent(Date.self, forKey: .lastStartedAt),
-      lastFinishedAt: try container.decodeIfPresent(Date.self, forKey: .lastFinishedAt),
-      lastSucceededAt: try container.decodeIfPresent(Date.self, forKey: .lastSucceededAt),
-      lastError: try container.decodeIfPresent(String.self, forKey: .lastError),
-      nextUpdateAt: try container.decodeIfPresent(Date.self, forKey: .nextUpdateAt),
-      backoffUntil: try container.decodeIfPresent(Date.self, forKey: .backoffUntil),
+      lastStartedAt: container.decodeIfPresent(Date.self, forKey: .lastStartedAt),
+      lastFinishedAt: container.decodeIfPresent(Date.self, forKey: .lastFinishedAt),
+      lastSucceededAt: container.decodeIfPresent(Date.self, forKey: .lastSucceededAt),
+      lastError: container.decodeIfPresent(String.self, forKey: .lastError),
+      nextUpdateAt: container.decodeIfPresent(Date.self, forKey: .nextUpdateAt),
+      backoffUntil: container.decodeIfPresent(Date.self, forKey: .backoffUntil),
       consecutiveFailures: container.decodeDefault(Int.self, forKey: .consecutiveFailures, default: 0)
     )
   }
@@ -1237,7 +1237,7 @@ enum SubscriptionPreflightDiagnosticFormatter {
     "can't find mmdb",
     "can't find geosite",
     "can't find geoip",
-    "start download"
+    "start download",
   ]
 
   // logrus levels (logfmt `level=...`) that indicate the real failure cause.
@@ -1453,12 +1453,12 @@ struct SubscriptionPreflightDiagnostics: Codable, Equatable, Sendable {
 
   init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
-    self.init(
-      checkedAt: try container.decodeIfPresent(Date.self, forKey: .checkedAt) ?? Date(),
-      result: try container.decode(SubscriptionPreflightResult.self, forKey: .result),
-      message: try container.decodeIfPresent(String.self, forKey: .message),
-      fullMessage: try container.decodeIfPresent(String.self, forKey: .fullMessage),
-      messageKind: try container.decodeIfPresent(SubscriptionPreflightDiagnosticMessage.self, forKey: .messageKind)
+    try self.init(
+      checkedAt: container.decodeIfPresent(Date.self, forKey: .checkedAt) ?? Date(),
+      result: container.decode(SubscriptionPreflightResult.self, forKey: .result),
+      message: container.decodeIfPresent(String.self, forKey: .message),
+      fullMessage: container.decodeIfPresent(String.self, forKey: .fullMessage),
+      messageKind: container.decodeIfPresent(SubscriptionPreflightDiagnosticMessage.self, forKey: .messageKind)
     )
   }
 
@@ -1534,9 +1534,9 @@ struct SubscriptionDiagnostics: Codable, Equatable, Sendable {
 
   init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
-    self.init(
-      latestFetch: try container.decodeIfPresent(SubscriptionFetchDiagnostics.self, forKey: .latestFetch),
-      latestPreflight: try container.decodeIfPresent(SubscriptionPreflightDiagnostics.self, forKey: .latestPreflight),
+    try self.init(
+      latestFetch: container.decodeIfPresent(SubscriptionFetchDiagnostics.self, forKey: .latestFetch),
+      latestPreflight: container.decodeIfPresent(SubscriptionPreflightDiagnostics.self, forKey: .latestPreflight),
       updateHistory: container.decodeDefault(
         [SubscriptionUpdateHistoryEntry].self,
         forKey: .updateHistory,
@@ -1998,7 +1998,7 @@ struct ProxyNodeKey: Identifiable, Hashable, Codable, Sendable {
       groupName,
       providerName,
       nodeName,
-      testURL
+      testURL,
     ]
     .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty }
     .joined(separator: "::")
@@ -2174,7 +2174,7 @@ struct ProxyDelayBatchProgress: Equatable, Sendable {
     if isRunning {
       return .running
     }
-    if cancelled > 0 && untestedCount > 0 {
+    if cancelled > 0, untestedCount > 0 {
       return .cancelled
     }
     if failureCount == 0 {
@@ -2249,12 +2249,12 @@ struct ExternalControllerCORSSettings: Codable, Equatable, Sendable {
   static let fixedLocalOrigins = [
     "tauri://localhost",
     "http://tauri.localhost",
-    "http://localhost:3000"
+    "http://localhost:3000",
   ]
   static let legacyDefaultPanelOrigins = [
     "https://yacd.metacubex.one",
     "https://metacubex.github.io",
-    "https://board.zash.run.place"
+    "https://board.zash.run.place",
   ]
   static let defaultPanelOrigins: [String] = []
 
@@ -2600,7 +2600,7 @@ struct ManagedRuleOverlayRule: Codable, Equatable, Identifiable, Sendable {
       components.append(normalizedValue)
     }
     components.append(normalizedPolicy)
-    if kind.allowsNoResolve && noResolve {
+    if kind.allowsNoResolve, noResolve {
       components.append("no-resolve")
     }
     return components.joined(separator: ",")
@@ -3004,6 +3004,7 @@ struct RuntimeOverrides: Codable, Equatable, Sendable {
       externalControllerHost = Self.normalizedExternalControllerHost(externalControllerHost)
     }
   }
+
   var externalControllerPort: Int
   var secret: String
   var allowLan: Bool
@@ -3150,7 +3151,7 @@ struct SystemProxySettings: Codable, Equatable, Sendable {
     "169.254/16",
     "10.0.0.0/8",
     "172.16.0.0/12",
-    "192.168.0.0/16"
+    "192.168.0.0/16",
   ]
 
   var proxyHost: String
@@ -3506,15 +3507,15 @@ struct TunDNSSettings: Codable, Equatable, Sendable {
       "routerlogin.net",
       "tplogin.cn",
       "miwifi.com",
-      "tendawifi.com"
+      "tendawifi.com",
     ],
     nameserver: [
       "https://dns.alidns.com/dns-query",
-      "https://doh.pub/dns-query"
+      "https://doh.pub/dns-query",
     ],
     fallback: [
       "tls://8.8.4.4",
-      "tls://1.1.1.1"
+      "tls://1.1.1.1",
     ]
   )
   static let `default` = chinaNetworkDefault
@@ -3524,11 +3525,11 @@ struct TunDNSSettings: Codable, Equatable, Sendable {
     defaultNameserver: ["1.1.1.1", "8.8.8.8"],
     nameserver: [
       "https://cloudflare-dns.com/dns-query",
-      "https://dns.google/dns-query"
+      "https://dns.google/dns-query",
     ],
     fallback: [
       "tls://1.1.1.1",
-      "tls://8.8.8.8"
+      "tls://8.8.8.8",
     ]
   )
   static let presets = [
@@ -3549,7 +3550,7 @@ struct TunDNSSettings: Codable, Equatable, Sendable {
       title: String(localized: "Global Secure"),
       description: String(localized: "Cloudflare and Google DoH/TLS resolvers with the standard fake-ip exclusions."),
       settings: .globalSecureDefault
-    )
+    ),
   ]
 
   var hasRuntimeOverlay: Bool {
@@ -3581,7 +3582,7 @@ struct TunDNSSettings: Codable, Equatable, Sendable {
       ("nameserver", nameserver),
       ("fallback", fallback),
       ("proxy-server-nameserver", proxyServerNameserver),
-      ("direct-nameserver", directNameserver)
+      ("direct-nameserver", directNameserver),
     ] {
       if let invalid = values.first(where: { !Self.isValidResolver($0) }) {
         return "Invalid TUN DNS \(title): \(invalid)"
@@ -3767,7 +3768,7 @@ struct TunDNSSettings: Codable, Equatable, Sendable {
       "server_failure",
       "name_error",
       "not_implemented",
-      "refused"
+      "refused",
     ].contains(String(code))
   }
 
@@ -3990,7 +3991,7 @@ struct TunSettings: Codable, Equatable, Sendable {
   }
 
   static func normalizedRouteExcludeCIDRs(_ values: [String]) -> [String] {
-    NetworkExtensionRoutingSettings.normalizedRouteExcludeCIDRs(values).filter(Self.isValidRouteExcludeCIDR)
+    NetworkExtensionRoutingSettings.normalizedRouteExcludeCIDRs(values).filter(isValidRouteExcludeCIDR)
   }
 
   private func normalizedList(_ values: [String], fallback: [String]) -> [String] {
@@ -4288,7 +4289,7 @@ struct GlobalShortcutSettings: Codable, Equatable, Sendable {
     let grouped = Dictionary(grouping: enabledBindings) { $0.shortcut?.identity ?? "" }
     return grouped.compactMap { _, bindings in
       guard bindings.count > 1 else { return nil }
-      return bindings.map { $0.action.displayName }.joined(separator: ", ")
+      return bindings.map(\.action.displayName).joined(separator: ", ")
     }
     .sorted()
   }
@@ -4380,11 +4381,12 @@ struct ProxyNode: Identifiable, Codable, Equatable, Sendable {
   var id: String {
     [
       providerName?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty,
-      name
+      name,
     ]
-    .compactMap { $0 }
+    .compactMap(\.self)
     .joined(separator: "::")
   }
+
   var name: String
   var type: String
   var delay: Int?
@@ -4440,18 +4442,18 @@ struct ProxyNode: Identifiable, Codable, Equatable, Sendable {
   init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let delay = try container.decodeIfPresent(Int.self, forKey: .delay)
-    self.init(
-      name: try container.decode(String.self, forKey: .name),
-      type: try container.decode(String.self, forKey: .type),
+    try self.init(
+      name: container.decode(String.self, forKey: .name),
+      type: container.decode(String.self, forKey: .type),
       delay: delay,
-      isSelectable: try container.decode(Bool.self, forKey: .isSelectable),
-      serverHost: try container.decodeIfPresent(String.self, forKey: .serverHost),
-      serverPort: try container.decodeIfPresent(Int.self, forKey: .serverPort),
-      providerName: try container.decodeIfPresent(String.self, forKey: .providerName),
-      udpSupported: try container.decodeIfPresent(Bool.self, forKey: .udpSupported),
-      tfoSupported: try container.decodeIfPresent(Bool.self, forKey: .tfoSupported),
-      xudpSupported: try container.decodeIfPresent(Bool.self, forKey: .xudpSupported),
-      delayState: try container.decodeIfPresent(ProxyDelayState.self, forKey: .delayState)
+      isSelectable: container.decode(Bool.self, forKey: .isSelectable),
+      serverHost: container.decodeIfPresent(String.self, forKey: .serverHost),
+      serverPort: container.decodeIfPresent(Int.self, forKey: .serverPort),
+      providerName: container.decodeIfPresent(String.self, forKey: .providerName),
+      udpSupported: container.decodeIfPresent(Bool.self, forKey: .udpSupported),
+      tfoSupported: container.decodeIfPresent(Bool.self, forKey: .tfoSupported),
+      xudpSupported: container.decodeIfPresent(Bool.self, forKey: .xudpSupported),
+      delayState: container.decodeIfPresent(ProxyDelayState.self, forKey: .delayState)
     )
   }
 
@@ -4669,7 +4671,7 @@ struct ConnectionSnapshot: Identifiable, Codable, Equatable, Sendable {
   }
 
   var ruleSummary: String {
-    [rule, rulePayload].compactMap { $0 }.joined(separator: " ")
+    [rule, rulePayload].compactMap(\.self).joined(separator: " ")
   }
 
   private static func endpointLabel(host: String?, port: Int?) -> String {
@@ -4748,7 +4750,7 @@ struct RuntimeRuleCandidate: Equatable, Sendable {
   var source: RuntimeRuleSource
 }
 
-struct RuntimeRuleCandidateBuilder {
+enum RuntimeRuleCandidateBuilder {
   static func runtimeCandidates(runtimeRules: [RuntimeRule]) -> [RuntimeRuleCandidate] {
     runtimeRules.enumerated().map { offset, rule in
       var runtimeRule = rule
@@ -4800,7 +4802,7 @@ struct RuntimeRuleCandidateBuilder {
   }
 }
 
-struct RuntimeRuleParser {
+enum RuntimeRuleParser {
   static func parse(raw: String, index: Int, providerName: String? = nil) -> RuntimeRule {
     let components = topLevelComponents(in: raw)
     let type = components.first?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
@@ -5207,7 +5209,7 @@ struct RuleExplanation: Equatable, Sendable {
   var ruleCount: Int
 
   var reportedRuleSummary: String {
-    [reportedRule, reportedRulePayload].compactMap { $0 }.joined(separator: " ")
+    [reportedRule, reportedRulePayload].compactMap(\.self).joined(separator: " ")
   }
 
   var chosenPolicySummary: String {
@@ -5388,7 +5390,7 @@ struct RuleExplanationBuilder: Sendable {
         value.destinationPort,
         value.sourcePort,
         value.inboundPort,
-        value.process
+        value.process,
       ]
       .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
       .joined(separator: "\u{1F}")
@@ -5405,7 +5407,7 @@ struct RuleExplanationBuilder: Sendable {
       input.sourceIP,
       input.destinationPort,
       input.sourcePort,
-      input.inboundPort
+      input.inboundPort,
     ]
     .compactMap { $0.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty }
     .first ?? ""
@@ -5447,12 +5449,12 @@ struct ExternalDashboardProfile: Identifiable, Codable, Equatable, Sendable {
 
   init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
-    self.init(
+    try self.init(
       id: container.decodeDefault(UUID.self, forKey: .id, default: UUID()),
       name: container.decodeDefault(String.self, forKey: .name, default: String(localized: "Dashboard")),
       url: container.decodeDefault(URL.self, forKey: .url, default: URL(string: "https://yacd.metacubex.one")!),
       readOnly: container.decodeDefault(Bool.self, forKey: .readOnly, default: true),
-      secretAccount: try container.decodeIfPresent(String.self, forKey: .secretAccount),
+      secretAccount: container.decodeIfPresent(String.self, forKey: .secretAccount),
       trustedForSecretAutofill: container.decodeDefault(Bool.self, forKey: .trustedForSecretAutofill, default: false)
     )
   }
@@ -5914,7 +5916,7 @@ struct ClientMigrationReport: Codable, Equatable, Sendable {
 
   init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
-    self.init(
+    try self.init(
       client: container.decodeDefault(MigrationClient.self, forKey: .client, default: .clashX),
       configDirectory: container.decodeDefault(String.self, forKey: .configDirectory, default: ""),
       localProfiles: container.decodeDefault([MigratedProfileCandidate].self, forKey: .localProfiles, default: []),
@@ -5929,10 +5931,10 @@ struct ClientMigrationReport: Codable, Equatable, Sendable {
       duplicateSubscriptionURLs: container.decodeDefault([String].self, forKey: .duplicateSubscriptionURLs, default: []),
       bypassDomains: container.decodeDefault([String].self, forKey: .bypassDomains, default: []),
       ports: container.decodeDefault([String: Int].self, forKey: .ports, default: [:]),
-      allowLan: try container.decodeIfPresent(Bool.self, forKey: .allowLan),
-      mode: try container.decodeIfPresent(String.self, forKey: .mode),
-      logLevel: try container.decodeIfPresent(String.self, forKey: .logLevel),
-      systemProxyEnabled: try container.decodeIfPresent(Bool.self, forKey: .systemProxyEnabled),
+      allowLan: container.decodeIfPresent(Bool.self, forKey: .allowLan),
+      mode: container.decodeIfPresent(String.self, forKey: .mode),
+      logLevel: container.decodeIfPresent(String.self, forKey: .logLevel),
+      systemProxyEnabled: container.decodeIfPresent(Bool.self, forKey: .systemProxyEnabled),
       conflicts: container.decodeDefault([String].self, forKey: .conflicts, default: []),
       unsupportedSettings: container.decodeDefault([String].self, forKey: .unsupportedSettings, default: []),
       unknownKeys: container.decodeDefault([String].self, forKey: .unknownKeys, default: []),

--- a/ClashMax/Models/DNSOverridePlan.swift
+++ b/ClashMax/Models/DNSOverridePlan.swift
@@ -139,7 +139,7 @@ struct DNSOverridePlan: Equatable, Sendable {
   var plainTextLines: [String] {
     var lines = [
       "DNS Override: \(hasOverride ? "Active" : "None")",
-      "DNS Enabled: \(isEnabled ? "yes" : "no") (\(enablement.rawValue))"
+      "DNS Enabled: \(isEnabled ? "yes" : "no") (\(enablement.rawValue))",
     ]
     if !overriddenFields.isEmpty {
       lines.append("Overridden Keys: \(overriddenFieldNames.joined(separator: ", "))")

--- a/ClashMax/Models/EffectiveRuntimeConfig.swift
+++ b/ClashMax/Models/EffectiveRuntimeConfig.swift
@@ -55,7 +55,7 @@ struct EffectiveRuntimeConfigSnapshot: Equatable, Sendable {
       "ClashMax Effective Runtime Config",
       "Generated: \(generatedAt.formatted(date: .numeric, time: .standard))",
       "Profile: \(profileName)",
-      "Preflight: \(preflightStatus.displayName)"
+      "Preflight: \(preflightStatus.displayName)",
     ]
     if let message = preflightStatus.message {
       lines.append("Preflight Detail: \(message)")

--- a/ClashMax/Models/KeyboardShortcutDescriptor.swift
+++ b/ClashMax/Models/KeyboardShortcutDescriptor.swift
@@ -140,20 +140,20 @@ struct KeyboardShortcutDescriptor: Codable, Equatable, Hashable, Sendable {
     var table: [String: KeyboardShortcuts.Key] = [:]
     let letters: [KeyboardShortcuts.Key] = [
       .a, .b, .c, .d, .e, .f, .g, .h, .i, .j, .k, .l, .m,
-      .n, .o, .p, .q, .r, .s, .t, .u, .v, .w, .x, .y, .z
+      .n, .o, .p, .q, .r, .s, .t, .u, .v, .w, .x, .y, .z,
     ]
     for (character, key) in zip("abcdefghijklmnopqrstuvwxyz", letters) {
       table[String(character)] = key
     }
     let digits: [KeyboardShortcuts.Key] = [
-      .zero, .one, .two, .three, .four, .five, .six, .seven, .eight, .nine
+      .zero, .one, .two, .three, .four, .five, .six, .seven, .eight, .nine,
     ]
     for (digit, key) in digits.enumerated() {
       table[String(digit)] = key
     }
     let functionKeys: [KeyboardShortcuts.Key] = [
       .f1, .f2, .f3, .f4, .f5, .f6, .f7, .f8, .f9, .f10,
-      .f11, .f12, .f13, .f14, .f15, .f16, .f17, .f18, .f19, .f20
+      .f11, .f12, .f13, .f14, .f15, .f16, .f17, .f18, .f19, .f20,
     ]
     for (index, key) in functionKeys.enumerated() {
       table["f\(index + 1)"] = key
@@ -172,7 +172,7 @@ struct KeyboardShortcutDescriptor: Codable, Equatable, Hashable, Sendable {
       "end": .end,
       "pageup": .pageUp,
       "pagedown": .pageDown,
-      "help": .help
+      "help": .help,
     ]
     let arrows: [String: KeyboardShortcuts.Key] = [
       "up": .upArrow,
@@ -186,7 +186,7 @@ struct KeyboardShortcutDescriptor: Codable, Equatable, Hashable, Sendable {
       "←": .leftArrow,
       "right": .rightArrow,
       "rightarrow": .rightArrow,
-      "→": .rightArrow
+      "→": .rightArrow,
     ]
     let punctuation: [String: KeyboardShortcuts.Key] = [
       "minus": .minus,
@@ -209,7 +209,7 @@ struct KeyboardShortcutDescriptor: Codable, Equatable, Hashable, Sendable {
       "leftbracket": .leftBracket,
       "[": .leftBracket,
       "rightbracket": .rightBracket,
-      "]": .rightBracket
+      "]": .rightBracket,
     ]
     for group in [named, arrows, punctuation] {
       table.merge(group) { current, _ in current }

--- a/ClashMax/Models/ProxyEffectDiagnostics.swift
+++ b/ClashMax/Models/ProxyEffectDiagnostics.swift
@@ -231,7 +231,8 @@ enum ProxyEffectDiagnosticsBuilder {
     }
     if input.routingMode == .neProxy,
        input.networkExtensionEnabled,
-       let neIssue = networkExtensionIssue(input.networkExtensionDiagnostics) {
+       let neIssue = networkExtensionIssue(input.networkExtensionDiagnostics)
+    {
       return make(
         status: .warn,
         cause: .networkExtensionDegraded,

--- a/ClashMax/Models/RuntimeSnippet.swift
+++ b/ClashMax/Models/RuntimeSnippet.swift
@@ -15,7 +15,7 @@ enum RuntimeSnippetBinding: Codable, Equatable, Sendable {
     let kind = try container.decodeIfPresent(String.self, forKey: .kind) ?? "allProfiles"
     switch kind {
     case "profiles":
-      self = .profiles(Self.normalizedProfileIDs(try container.decodeIfPresent([UUID].self, forKey: .profileIDs) ?? []))
+      self = try .profiles(Self.normalizedProfileIDs(container.decodeIfPresent([UUID].self, forKey: .profileIDs) ?? []))
     default:
       self = .allProfiles
     }
@@ -123,9 +123,9 @@ enum RuntimeSnippetPayload: Codable, Equatable, Sendable {
     let kind = try container.decodeIfPresent(RuntimeSnippetPayloadKind.self, forKey: .kind) ?? .rules
     switch kind {
     case .rules:
-      self = .rules(try container.decodeIfPresent(RuleOverlaySettings.self, forKey: .rules) ?? .disabled)
+      self = try .rules(container.decodeIfPresent(RuleOverlaySettings.self, forKey: .rules) ?? .disabled)
     case .dnsPatch:
-      self = .dnsPatch(try container.decodeIfPresent(TunDNSSettings.self, forKey: .dnsPatch) ?? .profileDefault)
+      self = try .dnsPatch(container.decodeIfPresent(TunDNSSettings.self, forKey: .dnsPatch) ?? .profileDefault)
     }
   }
 
@@ -221,12 +221,12 @@ struct RuntimeSnippet: Identifiable, Codable, Equatable, Sendable {
 
   init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
-    let decoded = RuntimeSnippet(
-      id: try container.decodeIfPresent(UUID.self, forKey: .id) ?? UUID(),
-      name: try container.decodeIfPresent(String.self, forKey: .name) ?? "",
-      enabled: try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? true,
-      binding: try container.decodeIfPresent(RuntimeSnippetBinding.self, forKey: .binding) ?? .allProfiles,
-      payload: try container.decodeIfPresent(RuntimeSnippetPayload.self, forKey: .payload)
+    let decoded = try RuntimeSnippet(
+      id: container.decodeIfPresent(UUID.self, forKey: .id) ?? UUID(),
+      name: container.decodeIfPresent(String.self, forKey: .name) ?? "",
+      enabled: container.decodeIfPresent(Bool.self, forKey: .enabled) ?? true,
+      binding: container.decodeIfPresent(RuntimeSnippetBinding.self, forKey: .binding) ?? .allProfiles,
+      payload: container.decodeIfPresent(RuntimeSnippetPayload.self, forKey: .payload)
         ?? .rules(.disabled)
     )
     self = decoded.foldingRulePayloadEnablementIntoSnippet()
@@ -332,7 +332,7 @@ struct RuntimeSnippetApplication: Equatable, Sendable {
       }
     }
     self.dnsPatches = dnsPatches
-    self.ruleOverlay = RuleOverlaySettings.combinedRuntimeSnippetOverlays(ruleOverlays)
+    ruleOverlay = RuleOverlaySettings.combinedRuntimeSnippetOverlays(ruleOverlays)
   }
 }
 
@@ -407,7 +407,7 @@ enum RuntimeSnippetYAMLPatchParser {
   }
 
   private static func dnsSettings(from dns: [String: Any]) throws -> TunDNSSettings {
-    let allowedKeys: Set<String> = [
+    let allowedKeys: Set = [
       "prefer-h3",
       "use-hosts",
       "use-system-hosts",
@@ -422,12 +422,12 @@ enum RuntimeSnippetYAMLPatchParser {
       "nameserver-policy",
       "proxy-server-nameserver-policy",
       "hosts",
-      "fallback-filter"
+      "fallback-filter",
     ]
     for key in dns.keys where !allowedKeys.contains(key) {
       throw ParserError.unsupportedDNSKey(key)
     }
-    return TunDNSSettings(
+    return try TunDNSSettings(
       preferH3: dns["prefer-h3"] as? Bool,
       useHosts: dns["use-hosts"] as? Bool,
       useSystemHosts: dns["use-system-hosts"] as? Bool,
@@ -442,7 +442,7 @@ enum RuntimeSnippetYAMLPatchParser {
       nameserverPolicy: stringMap(dns["nameserver-policy"]),
       proxyServerNameserverPolicy: stringMap(dns["proxy-server-nameserver-policy"]),
       hosts: stringMap(dns["hosts"]),
-      fallbackFilter: try fallbackFilter(dns["fallback-filter"])
+      fallbackFilter: fallbackFilter(dns["fallback-filter"])
     )
   }
 
@@ -469,7 +469,7 @@ enum RuntimeSnippetYAMLPatchParser {
 
   private static func fallbackFilter(_ value: Any?) throws -> TunDNSFallbackFilter {
     guard let map = value as? [String: Any] else { return .empty }
-    let allowedKeys: Set<String> = ["geoip", "geoip-code", "geosite", "ipcidr", "domain"]
+    let allowedKeys: Set = ["geoip", "geoip-code", "geosite", "ipcidr", "domain"]
     for key in map.keys where !allowedKeys.contains(key) {
       throw ParserError.unsupportedDNSKey("fallback-filter.\(key)")
     }

--- a/ClashMax/Services/AppRelocationService.swift
+++ b/ClashMax/Services/AppRelocationService.swift
@@ -12,16 +12,16 @@ enum AppRelocationError: LocalizedError, Equatable {
     case let .destinationOccupied(path):
       return String(
         localized: """
-          Another copy of ClashMax is already at \(path). Delete or rename it first, then move this \
-          copy into the Applications folder.
-          """
+        Another copy of ClashMax is already at \(path). Delete or rename it first, then move this \
+        copy into the Applications folder.
+        """
       )
     case .cannotRelocateTranslocatedBundle:
       return String(
         localized: """
-          macOS is running ClashMax from a protected temporary copy that cannot move itself. Drag \
-          ClashMax into your Applications folder in Finder, then open it from there.
-          """
+        macOS is running ClashMax from a protected temporary copy that cannot move itself. Drag \
+        ClashMax into your Applications folder in Finder, then open it from there.
+        """
       )
     case let .copyFailed(message):
       return String(localized: "Could not copy ClashMax into the Applications folder: \(message)")

--- a/ClashMax/Services/AppUpdateController.swift
+++ b/ClashMax/Services/AppUpdateController.swift
@@ -54,8 +54,7 @@ final class AppUpdateController: NSObject {
   }
 
   var versionSummary: String {
-    let displayVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "1.0.0"
-    return displayVersion
+    Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "1.0.0"
   }
 
   func checkForUpdates() {

--- a/ClashMax/Services/BackupRestoreService.swift
+++ b/ClashMax/Services/BackupRestoreService.swift
@@ -150,7 +150,8 @@ struct BackupRestoreService: Sendable {
     let profileSources: [BackupProfileSource]
     if let encryptedProfileSources = backup.encryptedProfileSources,
        let passwordForEncryptedPayloads,
-       !passwordForEncryptedPayloads.isEmpty {
+       !passwordForEncryptedPayloads.isEmpty
+    {
       profileSources = try decryptProfileSources(encryptedProfileSources, password: passwordForEncryptedPayloads)
       try Self.validateProfileSources(profileSources, against: backup.profilesManifest)
     } else {
@@ -403,7 +404,7 @@ struct BackupRestoreService: Sendable {
 
   private static func validate(_ backup: ClashMaxBackupFile) throws {
     guard backup.schemaVersion == 1
-            || backup.schemaVersion == ClashMaxBackupFile.currentSchemaVersion
+      || backup.schemaVersion == ClashMaxBackupFile.currentSchemaVersion
     else {
       throw BackupRestoreError.unsupportedSchema(backup.schemaVersion)
     }
@@ -626,7 +627,8 @@ struct BackupRestoreService: Sendable {
         }
       }
       if let upstreamEndpointID = profile.upstreamEndpointID,
-         !endpointIDs.contains(upstreamEndpointID) {
+         !endpointIDs.contains(upstreamEndpointID)
+      {
         throw BackupRestoreError.invalidBackup(
           "Profile upstream references an unknown outbound proxy endpoint."
         )
@@ -813,7 +815,7 @@ private enum BackupProfileSourceRedactor {
     guard credentialCount > 0 else {
       return (source, 0)
     }
-    return (try Yams.dump(object: redactedRoot, sortKeys: false), credentialCount)
+    return try (Yams.dump(object: redactedRoot, sortKeys: false), credentialCount)
   }
 
   private static func redact(
@@ -856,7 +858,8 @@ private enum BackupProfileSourceRedactor {
     }
     if normalized.contains("password")
       || normalized.contains("token")
-      || normalized.contains("secret") {
+      || normalized.contains("secret")
+    {
       return true
     }
     return [
@@ -868,7 +871,7 @@ private enum BackupProfileSourceRedactor {
       "proxy-authorization",
       "credential",
       "credentials",
-      "psk"
+      "psk",
     ].contains(normalized)
   }
 

--- a/ClashMax/Services/BundledCoreInfo.swift
+++ b/ClashMax/Services/BundledCoreInfo.swift
@@ -45,7 +45,8 @@ struct BundledCoreInfo: Equatable {
   private static func manifestURL(in bundle: Bundle) -> URL? {
     if let bundleManifestURL = bundle.resourceURL?
       .appendingPathComponent("Core", isDirectory: true)
-      .appendingPathComponent("mihomo-manifest.json") {
+      .appendingPathComponent("mihomo-manifest.json")
+    {
       return bundleManifestURL
     }
 

--- a/ClashMax/Services/ClashXMigrationParser.swift
+++ b/ClashMax/Services/ClashXMigrationParser.swift
@@ -44,7 +44,8 @@ struct ClientMigrationParser {
 
   private func detectedClient(in directoryURL: URL) -> MigrationClient {
     if fileManager.fileExists(atPath: directoryURL.appendingPathComponent("database.sqlite").path)
-      || flClashConfigMapURL(in: directoryURL) != nil {
+      || flClashConfigMapURL(in: directoryURL) != nil
+    {
       return .flClash
     }
     if looksLikeClashVergeDirectory(directoryURL) {
@@ -219,7 +220,8 @@ struct ClientMigrationParser {
     }
 
     if let configURL = flClashConfigMapURL(in: directoryURL),
-       let state = parseFlClashConfigMap(fileURL: configURL, warnings: &warnings) {
+       let state = parseFlClashConfigMap(fileURL: configURL, warnings: &warnings)
+    {
       appendInspectedFile(configURL, to: &inspectedFiles)
       for profile in state.profiles {
         profilesByID[profile.id] = profilesByID[profile.id] ?? profile
@@ -279,7 +281,8 @@ struct ClientMigrationParser {
         )
       }
       if let overwriteType = profile.overwriteType?.nilIfEmpty,
-         overwriteType.localizedCaseInsensitiveContains("script") {
+         overwriteType.localizedCaseInsensitiveContains("script")
+      {
         appendUnsupportedMapping(
           client: .flClash,
           source: "profiles[\(profile.id)]",
@@ -553,19 +556,19 @@ struct ClientMigrationParser {
       "profiles.yaml",
       "profiles.yml",
       "proxy-providers.yaml",
-      "proxy-providers.yml"
+      "proxy-providers.yml",
     ]
     var result: [URL] = commonFiles
       .map { directoryURL.appendingPathComponent($0) }
       .filter { fileManager.fileExists(atPath: $0.path) }
 
-    let commonSubfolders: Set<String> = [
+    let commonSubfolders: Set = [
       "profiles",
       "providers",
       "proxy-providers",
       "rule-providers",
       "clash",
-      "config"
+      "config",
     ]
     guard let enumerator = fileManager.enumerator(
       at: directoryURL,
@@ -599,7 +602,7 @@ struct ClientMigrationParser {
           filePath: fileURL.path,
           source: fileName,
           note: "Original YAML is imported unchanged."
-        )
+        ),
       ]
     }
     return []
@@ -632,7 +635,8 @@ struct ClientMigrationParser {
       } else if let values = root[key] as? [String: Any] {
         for entry in values {
           if let value = entry.value as? [String: Any],
-             let url = stringValue(value["url"]) ?? stringValue(value["uri"]) {
+             let url = stringValue(value["url"]) ?? stringValue(value["uri"])
+          {
             subscriptionEntries.append((name: entry.key, url: url, file: fileLabel))
           } else if let url = stringValue(entry.value) {
             subscriptionEntries.append((name: entry.key, url: url, file: fileLabel))
@@ -729,7 +733,7 @@ struct ClientMigrationParser {
   }
 
   private func unknownTopLevelKeys(from root: [String: Any]) -> [String] {
-    let known: Set<String> = [
+    let known: Set = [
       "allow-lan",
       "authentication",
       "bypass",
@@ -771,7 +775,7 @@ struct ClientMigrationParser {
       "system-proxy",
       "tproxy-port",
       "tray",
-      "tun"
+      "tun",
     ]
     return root.keys.filter { !known.contains($0.lowercased()) }.sorted()
   }
@@ -877,7 +881,8 @@ struct ClientMigrationParser {
         let name: String
         if let profileID,
            let rawProfileID = profileID.replacingOccurrences(of: "flclash-profile-", with: "").nilIfEmpty,
-           let profile = profilesByID[rawProfileID] {
+           let profile = profilesByID[rawProfileID]
+        {
           name = "FlClash \(profile.displayName) Rules"
         } else {
           name = "FlClash Global Rules"
@@ -988,7 +993,7 @@ struct ClientMigrationParser {
       "dangerAcceptInvalidCerts": "report only",
       "selected": "report only",
       "extra": "report only",
-      "home": "report only"
+      "home": "report only",
     ]
     for (field, action) in unsupportedFields.sorted(by: { $0.key < $1.key }) where option[field] != nil {
       appendUnsupportedMapping(
@@ -1097,7 +1102,7 @@ struct ClientMigrationParser {
     var buffer = ""
     var depth = 0
     for character in rawRule {
-      if character == "," && depth == 0 {
+      if character == ",", depth == 0 {
         parts.append(buffer.trimmingCharacters(in: .whitespacesAndNewlines))
         buffer = ""
         continue
@@ -1170,7 +1175,7 @@ struct ClientMigrationParser {
       "config.json",
       "config.yaml",
       "config.yml",
-      "shared_preferences.json"
+      "shared_preferences.json",
     ]
     for name in candidateNames {
       let url = directoryURL.appendingPathComponent(name)
@@ -1178,7 +1183,8 @@ struct ClientMigrationParser {
             let root = loadMapping(from: url)
       else { continue }
       if root["configMap"] != nil
-        || (root["profiles"] != nil && (root["links"] != nil || root["profile_rule_mapping"] != nil || root["profileRuleMapping"] != nil)) {
+        || (root["profiles"] != nil && (root["links"] != nil || root["profile_rule_mapping"] != nil || root["profileRuleMapping"] != nil))
+      {
         return url
       }
     }

--- a/ClashMax/Services/ConfigNormalizer.swift
+++ b/ClashMax/Services/ConfigNormalizer.swift
@@ -27,7 +27,7 @@ struct ConfigNormalizer {
     "IP-CIDR6,::1/128,DIRECT,no-resolve",
     "IP-CIDR6,fc00::/7,DIRECT,no-resolve",
     "IP-CIDR6,fe80::/10,DIRECT,no-resolve",
-    "MATCH,Proxy"
+    "MATCH,Proxy",
   ]
 
   enum NormalizerError: Error, CustomStringConvertible, LocalizedError, Sendable {
@@ -115,7 +115,7 @@ struct ConfigNormalizer {
     if overrides.externalControllerCORS.enabled {
       root["external-controller-cors"] = [
         "allow-origins": overrides.externalControllerCORS.effectiveAllowedOrigins,
-        "allow-private-network": overrides.externalControllerCORS.allowPrivateNetwork
+        "allow-private-network": overrides.externalControllerCORS.allowPrivateNetwork,
       ]
     } else {
       root.removeValue(forKey: "external-controller-cors")
@@ -212,7 +212,8 @@ struct ConfigNormalizer {
     }
 
     if !selectionOverrides.isEmpty,
-       var groups = root["proxy-groups"] as? [Any] {
+       var groups = root["proxy-groups"] as? [Any]
+    {
       for index in groups.indices {
         guard var group = groups[index] as? [String: Any],
               let groupName = group["name"] as? String,
@@ -239,11 +240,11 @@ struct ConfigNormalizer {
       root = try applyingUpstreamProxy(upstreamProxyEndpoint, to: root)
     }
     applyOutboundProxyDNSBootstrap(
-      for: [options.manualProxyEndpoint, options.upstreamProxyEndpoint].compactMap { $0 },
+      for: [options.manualProxyEndpoint, options.upstreamProxyEndpoint].compactMap(\.self),
       to: &root
     )
     try applyTCPOnlyOutboundPolicy(
-      for: [options.manualProxyEndpoint, options.upstreamProxyEndpoint].compactMap { $0 },
+      for: [options.manualProxyEndpoint, options.upstreamProxyEndpoint].compactMap(\.self),
       overrides: overrides,
       options: options,
       to: &root
@@ -273,13 +274,14 @@ struct ConfigNormalizer {
   ) throws {
     if let manualProxyEndpoint = options.manualProxyEndpoint,
        let upstreamProxyEndpoint = options.upstreamProxyEndpoint,
-       manualProxyEndpoint.endpoint.id == upstreamProxyEndpoint.endpoint.id {
+       manualProxyEndpoint.endpoint.id == upstreamProxyEndpoint.endpoint.id
+    {
       throw NormalizerError.invalidProfile(
         "The manual proxy and upstream proxy cannot use the same endpoint."
       )
     }
 
-    for resolvedEndpoint in [options.manualProxyEndpoint, options.upstreamProxyEndpoint].compactMap({ $0 }) {
+    for resolvedEndpoint in [options.manualProxyEndpoint, options.upstreamProxyEndpoint].compactMap(\.self) {
       let endpoint = resolvedEndpoint.endpoint
       guard resolvedEndpoint.isReady else {
         throw NormalizerError.invalidProfile(
@@ -325,7 +327,8 @@ struct ConfigNormalizer {
 
     for group in (root["proxy-groups"] as? [Any] ?? []).compactMap({ $0 as? [String: Any] }) {
       if let name = Self.trimmedString(group["name"]),
-         Self.isReservedOutboundProxyName(name) {
+         Self.isReservedOutboundProxyName(name)
+      {
         throw NormalizerError.invalidProfile(
           "Runtime config contains a name reserved for ClashMax outbound proxies."
         )
@@ -359,10 +362,10 @@ struct ConfigNormalizer {
         [
           "name": "Proxy",
           "type": "select",
-          "proxies": [name]
-        ]
+          "proxies": [name],
+        ],
       ],
-      "rules": Self.manualProxyRules
+      "rules": Self.manualProxyRules,
     ]
   }
 
@@ -385,7 +388,7 @@ struct ConfigNormalizer {
       "reject-drop",
       "dns",
       "pass",
-      "compatible"
+      "compatible",
     ]
 
     var proxies = root["proxies"] as? [Any] ?? []
@@ -498,7 +501,7 @@ struct ConfigNormalizer {
       "name": Self.outboundProxyName(for: endpoint.id),
       "type": endpoint.kind.rawValue,
       "server": endpoint.host,
-      "port": endpoint.port
+      "port": endpoint.port,
     ]
     switch endpoint.kind {
     case .socks5:
@@ -561,7 +564,7 @@ struct ConfigNormalizer {
 
     var ipv4 = in_addr()
     if normalized.withCString({ inet_pton(AF_INET, $0, &ipv4) }) == 1 {
-      return UInt32(bigEndian: ipv4.s_addr) & 0xFF00_0000 == 0x7F00_0000
+      return UInt32(bigEndian: ipv4.s_addr) & 0xff00_0000 == 0x7f00_0000
     }
 
     var ipv6 = in6_addr()
@@ -580,7 +583,7 @@ struct ConfigNormalizer {
       return true
     }
     var ipv6 = in6_addr()
-    return normalized.withCString({ inet_pton(AF_INET6, $0, &ipv6) }) == 1
+    return normalized.withCString { inet_pton(AF_INET6, $0, &ipv6) } == 1
   }
 
   private static func normalizedIPAddressHost(_ host: String) -> String {
@@ -635,11 +638,13 @@ struct ConfigNormalizer {
 
   private func mergedRuntimeValue(base: Any, overlay: Any) -> Any {
     if let baseMap = base as? [String: Any],
-       let overlayMap = overlay as? [String: Any] {
+       let overlayMap = overlay as? [String: Any]
+    {
       return mergedRuntimeMapping(base: baseMap, overlay: overlayMap)
     }
     if let baseList = base as? [Any],
-       let overlayList = overlay as? [Any] {
+       let overlayList = overlay as? [Any]
+    {
       return baseList + overlayList
     }
     return overlay
@@ -894,8 +899,8 @@ struct ConfigNormalizer {
         "url": AppConstants.defaultDelayTestURL.absoluteString,
         "interval": 300,
         "timeout": 5000,
-        "lazy": true
-      ]
+        "lazy": true,
+      ],
     ]
     let filter = options.filter.trimmingCharacters(in: .whitespacesAndNewlines)
     if !filter.isEmpty {
@@ -928,8 +933,8 @@ struct ConfigNormalizer {
         "name": primaryGroupName,
         "type": "select",
         "use": [providerName],
-        "proxies": ([autoGroupName.isEmpty ? nil : autoGroupName, "DIRECT"] as [String?]).compactMap { $0 }
-      ]
+        "proxies": ([autoGroupName.isEmpty ? nil : autoGroupName, "DIRECT"] as [String?]).compactMap(\.self),
+      ],
     ]
     if !autoGroupName.isEmpty {
       proxyGroups.append([
@@ -938,16 +943,16 @@ struct ConfigNormalizer {
         "use": [providerName],
         "url": AppConstants.defaultDelayTestURL.absoluteString,
         "interval": 300,
-        "lazy": true
+        "lazy": true,
       ])
     }
 
     var root: [String: Any] = [
       "proxy-providers": [
-        providerName: provider
+        providerName: provider,
       ],
       "proxy-groups": proxyGroups,
-      "rules": generatedRules(template: options.generatedTemplate, finalRulePolicy: finalRulePolicy)
+      "rules": generatedRules(template: options.generatedTemplate, finalRulePolicy: finalRulePolicy),
     ]
     if SubscriptionTemplateKind.emitsDNSBase(version: options.generatedTemplateVersion) {
       root["dns"] = providerTemplateDNS(ipv6Enabled: ipv6Enabled)
@@ -965,7 +970,7 @@ struct ConfigNormalizer {
       "fake-ip-range": TunSettings.defaultFakeIPRange,
       "default-nameserver": [
         "223.5.5.5",
-        "119.29.29.29"
+        "119.29.29.29",
       ],
       // Required by the `respect-rules: true` above: Mihomo refuses to start without it, so the
       // generated template used to produce a config the core rejected outright (issue #16). Plain
@@ -973,15 +978,15 @@ struct ConfigNormalizer {
       // work before any proxy is reachable.
       "proxy-server-nameserver": [
         "223.5.5.5",
-        "119.29.29.29"
+        "119.29.29.29",
       ],
       "fallback-filter": [
         "geoip": true,
         "geoip-code": "CN",
         "ipcidr": [
-          "240.0.0.0/4"
-        ]
-      ]
+          "240.0.0.0/4",
+        ],
+      ],
     ]
     applyTunDNSOverlay(.chinaNetworkDefault, to: &dns)
     return dns
@@ -998,7 +1003,7 @@ struct ConfigNormalizer {
         "IP-CIDR,10.0.0.0/8,DIRECT,no-resolve",
         "IP-CIDR,172.16.0.0/12,DIRECT,no-resolve",
         "IP-CIDR,192.168.0.0/16,DIRECT,no-resolve",
-        "MATCH,\(finalRulePolicy)"
+        "MATCH,\(finalRulePolicy)",
       ]
     case .cnDirect:
       return [
@@ -1007,7 +1012,7 @@ struct ConfigNormalizer {
         "GEOIP,private,DIRECT,no-resolve",
         "GEOSITE,cn,DIRECT",
         "GEOIP,CN,DIRECT,no-resolve",
-        "MATCH,\(finalRulePolicy)"
+        "MATCH,\(finalRulePolicy)",
       ]
     }
   }
@@ -1072,7 +1077,7 @@ enum ProfileConfigInspector {
     "ovpn",
     "gost",
     "sudoku",
-    "hy"
+    "hy",
   ]
 
   static func format(of source: String) throws -> ProfileConfigFormat {
@@ -1113,7 +1118,8 @@ enum ProfileConfigInspector {
       throw ProfileConfigFormatError.empty
     }
     if let decoded = decodedBase64ProviderContent(from: source),
-       isProviderContentText(decoded) {
+       isProviderContentText(decoded)
+    {
       return .base64ShareLinkList
     }
     do {
@@ -1182,7 +1188,7 @@ enum ProfileConfigInspector {
       "tproxy-port",
       "tun",
       "dns",
-      "mode"
+      "mode",
     ].contains { root[$0] != nil }
   }
 
@@ -1295,7 +1301,7 @@ struct ProfilePreviewBuilder {
             delay: nil,
             isSelectable: false,
             providerName: providerName
-          )
+          ),
         ]
       }
       if nodes.isEmpty {
@@ -1366,15 +1372,15 @@ struct ProfilePreviewBuilder {
         type: "url-test",
         selected: nil,
         nodes: providerNodes
-      )
+      ),
     ]
   }
 
   private func providerURINodes(from source: String) -> [ProxyNode] {
     let candidates = [
       source,
-      ProfileConfigInspector.decodedBase64ProviderContent(from: source)
-    ].compactMap { $0 }
+      ProfileConfigInspector.decodedBase64ProviderContent(from: source),
+    ].compactMap(\.self)
 
     for candidate in candidates {
       let nodes = candidate
@@ -1415,7 +1421,8 @@ struct ProfilePreviewBuilder {
     if let fragmentStart = uri.firstIndex(of: "#") {
       let encodedName = String(uri[uri.index(after: fragmentStart)...])
       if let decoded = encodedName.removingPercentEncoding,
-         !decoded.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+         !decoded.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+      {
         return decoded
       }
     }

--- a/ClashMax/Services/CoreProcessController.swift
+++ b/ClashMax/Services/CoreProcessController.swift
@@ -116,6 +116,7 @@ final class CoreProcessController {
       onStatusChange?(status)
     }
   }
+
   private(set) var recentCoreLog: String = ""
   private(set) var startupDiagnostics: [String] = []
   private let launcher: CoreProcessLaunching
@@ -169,7 +170,7 @@ final class CoreProcessController {
       await reaper.reapOrphans(coreURL: coreURL, configURL: configURL, workDirectory: workDirectory)
       try Task.checkCancellation()
 
-      let portsToCheck = Array(Set(([api.port] + [proxyPort].compactMap { $0 }))).sorted()
+      let portsToCheck = Array(Set([api.port] + [proxyPort].compactMap(\.self))).sorted()
       recordStartup("Checking runtime ports: \(portsToCheck.map(String.init).joined(separator: ", "))")
       let listeners = await portChecker.listeners(on: portsToCheck)
       if !listeners.isEmpty {
@@ -186,7 +187,7 @@ final class CoreProcessController {
         environment: [
           "SAFE_PATHS": workDirectory.path,
           "CLASHMAX_API_HOST": api.host,
-          "CLASHMAX_API_PORT": String(api.port)
+          "CLASHMAX_API_PORT": String(api.port),
         ],
         workDirectory: workDirectory
       )
@@ -198,19 +199,19 @@ final class CoreProcessController {
       runningProcess = process
       process.onTermination = { [weak self, weak process] exitCode in
         guard let self else { return }
-        guard self.runningProcess?.processIdentifier == launchedProcessID else { return }
-        if self.stopWasRequested || (startupCompleted && exitCode == 0) {
-          self.status = .stopped
+        guard runningProcess?.processIdentifier == launchedProcessID else { return }
+        if stopWasRequested || (startupCompleted && exitCode == 0) {
+          status = .stopped
         } else {
           let tail = process?.recentOutputTail(maxBytes: 4096) ?? ""
           let message = Self.processExitMessage(exitCode: exitCode, outputTail: tail)
           if !startupCompleted {
             startupTerminationMessage = message
-            self.recentCoreLog = tail
+            recentCoreLog = tail
           }
-          self.status = .crashed(message: message)
+          status = .crashed(message: message)
         }
-        self.runningProcess = nil
+        runningProcess = nil
       }
       if let startupTerminationMessage {
         recordStartup("Mihomo exited before controller readiness: \(startupTerminationMessage)")
@@ -350,7 +351,7 @@ final class CoreProcessController {
 
   private func waitForExit(_ process: RunningCoreProcess, processIdentifier: Int32, timeout: TimeInterval) async -> Bool {
     let deadline = Date().addingTimeInterval(timeout)
-    while process.isRunning && Date() < deadline {
+    while process.isRunning, Date() < deadline {
       if runningProcess?.processIdentifier != processIdentifier {
         return true
       }
@@ -407,7 +408,7 @@ struct MihomoRuntimePortChecker: RuntimePortChecking {
   func listeners(on ports: [Int]) async -> [PortListener] {
     var listeners: [PortListener] = []
     for port in ports {
-      listeners.append(contentsOf: await Self.listeners(on: port))
+      await listeners.append(contentsOf: Self.listeners(on: port))
     }
     return listeners
   }
@@ -478,7 +479,7 @@ struct ProcessOutputCapture: Sendable {
           domain: "ClashMax.ProcessOutputCapture",
           code: Int(ETIMEDOUT),
           userInfo: [
-            NSLocalizedDescriptionKey: "Command timed out after \(timeout)s: \(command)\(output.isEmpty ? "" : "\n\(output)")"
+            NSLocalizedDescriptionKey: "Command timed out after \(timeout)s: \(command)\(output.isEmpty ? "" : "\n\(output)")",
           ]
         )
       },
@@ -588,8 +589,7 @@ final class CancellableProcessExecution: @unchecked Sendable {
       do {
         try await Task.sleep(nanoseconds: Self.nanoseconds(for: self?.timeout ?? 0))
         self?.requestStop(.timedOut)
-      } catch {
-      }
+      } catch {}
     }
   }
 
@@ -755,13 +755,13 @@ struct MihomoOrphanProcessReaper: CoreProcessReaping {
     guard !signaledPIDs.isEmpty else { return }
 
     let deadline = now().addingTimeInterval(terminationGracePeriod)
-    while now() < deadline && signaledPIDs.contains(where: { pid in
+    while now() < deadline, signaledPIDs.contains(where: { pid in
       Self.isProcessSignalableAlive(pid, signalSender: signalSender, eventLogger: eventLogger)
     }) {
       await sleeper(Self.terminationPollIntervalNanoseconds)
     }
-    let latestManagedPIDs = Set(Self.managedPIDs(
-      from: await processRowsProvider(),
+    let latestManagedPIDs = await Set(Self.managedPIDs(
+      from: processRowsProvider(),
       currentPID: currentPID,
       coreURL: coreURL,
       configURL: configURL,
@@ -788,7 +788,7 @@ struct MihomoOrphanProcessReaper: CoreProcessReaping {
 
     let pathComponents = workDirectory.pathComponents
     let isClashMaxRuntime = pathComponents.suffix(2) == ["ClashMax", "Runtime"]
-    if isClashMaxRuntime && command.contains(workDirectory.path) {
+    if isClashMaxRuntime, command.contains(workDirectory.path) {
       return true
     }
 
@@ -895,7 +895,7 @@ struct MihomoRuntimeConfigValidator: RuntimeConfigValidating {
     try await Self.validateAsync(coreURL: coreURL, configURL: configURL, workDirectory: workDirectory, timeout: timeout)
   }
 
-  nonisolated private static func validateAsync(coreURL: URL, configURL: URL, workDirectory: URL, timeout: TimeInterval) async throws {
+  private nonisolated static func validateAsync(coreURL: URL, configURL: URL, workDirectory: URL, timeout: TimeInterval) async throws {
     let process = Process()
     let stdoutPipe = Pipe()
     let stderrPipe = Pipe()
@@ -903,7 +903,7 @@ struct MihomoRuntimeConfigValidator: RuntimeConfigValidating {
     process.arguments = ["-t", "-f", configURL.path, "-d", workDirectory.path]
     process.currentDirectoryURL = workDirectory
     process.environment = ProcessInfo.processInfo.environment.merging([
-      "SAFE_PATHS": workDirectory.path
+      "SAFE_PATHS": workDirectory.path,
     ]) { _, new in new }
     process.standardOutput = stdoutPipe
     process.standardError = stderrPipe
@@ -920,7 +920,7 @@ struct MihomoRuntimeConfigValidator: RuntimeConfigValidating {
           domain: "ClashMax.CoreValidation",
           code: Int(ETIMEDOUT),
           userInfo: [
-            NSLocalizedDescriptionKey: "Runtime config validation timed out after \(timeout)s.\(output.isEmpty ? "" : "\n\(output)")"
+            NSLocalizedDescriptionKey: "Runtime config validation timed out after \(timeout)s.\(output.isEmpty ? "" : "\n\(output)")",
           ]
         )
       },
@@ -961,8 +961,8 @@ struct MihomoCoreReadinessProbe: CoreReadinessProbing {
   }
 
   func waitUntilReady(api: CoreAPIEndpoint) async throws -> String {
-    let client = MihomoAPIClient(
-      baseURL: try api.baseURL,
+    let client = try MihomoAPIClient(
+      baseURL: api.baseURL,
       secret: api.secret,
       session: session,
       requestTimeout: requestTimeout
@@ -1149,7 +1149,7 @@ final class LiveOutputDrain: @unchecked Sendable {
     onOutput: (@Sendable (ProcessOutputLine) -> Void)? = nil
   ) {
     self.maxRetainedBytes = maxRetainedBytes
-    self.isSanitized = sanitized
+    isSanitized = sanitized
     self.onOutput = onOutput
     guard sanitized else { return }
     let home = homeDirectory ?? NSHomeDirectory()

--- a/ClashMax/Services/EffectiveRuntimeConfigBuilder.swift
+++ b/ClashMax/Services/EffectiveRuntimeConfigBuilder.swift
@@ -166,7 +166,7 @@ struct EffectiveRuntimeConfigBuilder {
     var diffRows: [EffectiveRuntimeConfigDiffRow]
   }
 
-  nonisolated private static func makePresentation(
+  private nonisolated static func makePresentation(
     originalConfigPath: String,
     runtimeConfigURL: URL,
     providerContentURL: URL?,
@@ -209,7 +209,7 @@ struct EffectiveRuntimeConfigBuilder {
 
   /// Provider content and other non-mapping sources simply have no `dns:` block; `.absent` is the
   /// honest baseline there, and every DNS key in the generated YAML is then an app-managed override.
-  nonisolated private static func dnsFacts(inYAML yaml: String) -> DNSRuntimeFacts {
+  private nonisolated static func dnsFacts(inYAML yaml: String) -> DNSRuntimeFacts {
     guard let root = (try? Yams.load(yaml: yaml)) as? [String: Any] else { return .absent }
     return DNSRuntimeFacts.facts(from: root["dns"])
   }
@@ -352,7 +352,7 @@ struct EffectiveRuntimeConfigBuilder {
         title: "Final runtime YAML",
         summary: String(localized: "Final generated YAML used by Mihomo after app-managed overlays."),
         redactedContent: redactedFinal
-      )
+      ),
     ]
   }
 
@@ -379,7 +379,7 @@ struct EffectiveRuntimeConfigBuilder {
       "server: \(endpoint.host)",
       "port: \(endpoint.port)",
       "status: \(resolvedEndpoint.secretState.rawValue)",
-      "transport: \(tcpOnly ? "TCP only" : "TCP and UDP")"
+      "transport: \(tcpOnly ? "TCP only" : "TCP and UDP")",
     ].joined(separator: "\n")
     return EffectiveRuntimeConfigLayer(
       id: id,
@@ -414,7 +414,7 @@ struct EffectiveRuntimeConfigBuilder {
       "Provider Interval: \(options.intervalSeconds)s",
       "Custom Headers: \(options.normalizedHeaders.count)",
       "Provider Rule Overlay:",
-      renderRuleOverlay(options.ruleOverlay)
+      renderRuleOverlay(options.ruleOverlay),
     ]
     let overrideYAML = options.overrideYAML.trimmingCharacters(in: .whitespacesAndNewlines)
     if !overrideYAML.isEmpty {
@@ -446,10 +446,10 @@ struct EffectiveRuntimeConfigBuilder {
         "Snippet: \(snippet.normalizedName.isEmpty ? String(localized: "Untitled Snippet") : snippet.normalizedName)",
         "Binding: \(snippet.binding.displayName)",
         "Payload: \(snippet.payload.summary)",
-        renderSnippetPayload(snippet.payload)
+        renderSnippetPayload(snippet.payload),
       ]
-        .filter { !$0.isEmpty }
-        .joined(separator: "\n")
+      .filter { !$0.isEmpty }
+      .joined(separator: "\n")
     }
     .joined(separator: "\n\n")
   }
@@ -464,7 +464,7 @@ struct EffectiveRuntimeConfigBuilder {
   }
 
   private func renderRuleOverlay(_ overlay: RuleOverlaySettings) -> String {
-    var lines: [String] = ["Enabled: \(overlay.enabled ? "yes" : "no")"]
+    var lines = ["Enabled: \(overlay.enabled ? "yes" : "no")"]
     if !overlay.runtimePrependRules.isEmpty {
       lines.append("Before:")
       lines.append(contentsOf: overlay.runtimePrependRules.map { "- \($0)" })
@@ -530,14 +530,15 @@ enum RuntimeConfigDisplayRedactor {
     providerContentPaths: [String] = []
   ) -> String {
     if let loaded = try? Yams.load(yaml: text),
-       (loaded is [String: Any] || loaded is [Any]),
+       loaded is [String: Any] || loaded is [Any],
        let redactedObject = redactedYAMLValue(
-        loaded,
-        path: [],
-        controllerSecret: controllerSecret,
-        providerContentPaths: providerContentPaths
+         loaded,
+         path: [],
+         controllerSecret: controllerSecret,
+         providerContentPaths: providerContentPaths
        ),
-       let dumped = try? Yams.dump(object: redactedObject, sortKeys: false) {
+       let dumped = try? Yams.dump(object: redactedObject, sortKeys: false)
+    {
       return redactScalarSecrets(dumped, controllerSecret: controllerSecret, providerContentPaths: providerContentPaths)
     }
     if ProfileConfigInspector.isProxyProviderContent(text) {
@@ -596,7 +597,8 @@ enum RuntimeConfigDisplayRedactor {
     }
     if normalized.contains("password")
       || normalized.contains("token")
-      || normalized.contains("secret") {
+      || normalized.contains("secret")
+    {
       return true
     }
     return [
@@ -608,7 +610,7 @@ enum RuntimeConfigDisplayRedactor {
       "proxy-authorization",
       "credential",
       "credentials",
-      "psk"
+      "psk",
     ].contains(normalized)
   }
 
@@ -830,7 +832,8 @@ enum EffectiveRuntimeConfigLineDiff {
     let limit = min(oldLimit, newLimit)
     var count = 0
     while count < limit,
-          oldLines[oldLines.count - count - 1] == newLines[newLines.count - count - 1] {
+          oldLines[oldLines.count - count - 1] == newLines[newLines.count - count - 1]
+    {
       count += 1
     }
     return count

--- a/ClashMax/Services/HelperSetupGuidance.swift
+++ b/ClashMax/Services/HelperSetupGuidance.swift
@@ -33,16 +33,16 @@ enum AppInstallLocationIssue: Equatable, Sendable {
     case .translocated:
       return String(
         localized: """
-          macOS is running ClashMax from a temporary read-only copy, which it will not let install a \
-          privileged helper. Drag ClashMax into your Applications folder in Finder, then open it from there.
-          """
+        macOS is running ClashMax from a temporary read-only copy, which it will not let install a \
+        privileged helper. Drag ClashMax into your Applications folder in Finder, then open it from there.
+        """
       )
     case let .outsideApplications(folderName):
       return String(
         localized: """
-          ClashMax is running from “\(folderName)”. macOS only allows a privileged helper to be \
-          installed from the Applications folder.
-          """
+        ClashMax is running from “\(folderName)”. macOS only allows a privileged helper to be \
+        installed from the Applications folder.
+        """
       )
     }
   }

--- a/ClashMax/Services/KeychainStore.swift
+++ b/ClashMax/Services/KeychainStore.swift
@@ -19,11 +19,11 @@ struct KeychainStore: SecretStoring {
     let query: [String: Any] = [
       kSecClass as String: kSecClassGenericPassword,
       kSecAttrService as String: service,
-      kSecAttrAccount as String: account
+      kSecAttrAccount as String: account,
     ]
     let attributes: [String: Any] = [
       kSecValueData as String: data,
-      kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+      kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
     ]
 
     let status = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
@@ -44,7 +44,7 @@ struct KeychainStore: SecretStoring {
       kSecAttrService as String: service,
       kSecAttrAccount as String: account,
       kSecReturnData as String: true,
-      kSecMatchLimit as String: kSecMatchLimitOne
+      kSecMatchLimit as String: kSecMatchLimitOne,
     ]
     var result: CFTypeRef?
     let status = SecItemCopyMatching(query as CFDictionary, &result)
@@ -58,10 +58,10 @@ struct KeychainStore: SecretStoring {
     let query: [String: Any] = [
       kSecClass as String: kSecClassGenericPassword,
       kSecAttrService as String: service,
-      kSecAttrAccount as String: account
+      kSecAttrAccount as String: account,
     ]
     let status = SecItemDelete(query as CFDictionary)
-    if status != errSecSuccess && status != errSecItemNotFound {
+    if status != errSecSuccess, status != errSecItemNotFound {
       throw keychainError(status)
     }
   }

--- a/ClashMax/Services/MihomoAPIClient.swift
+++ b/ClashMax/Services/MihomoAPIClient.swift
@@ -70,7 +70,7 @@ struct MihomoAPIClient: Sendable {
 
   func configs() async throws -> [String: Any] {
     let data = try await data(for: request(path: "/configs"))
-    return (try JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
+    return try (JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
   }
 
   func updateMode(_ mode: RunMode) async throws {
@@ -165,7 +165,7 @@ struct MihomoAPIClient: Sendable {
 
   func proxyProviders() async throws -> [String: Any] {
     let data = try await data(for: request(path: "/providers/proxies"))
-    return (try JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
+    return try (JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
   }
 
   func structuredProxyProviders() async throws -> [ProxyProvider] {
@@ -203,7 +203,7 @@ struct MihomoAPIClient: Sendable {
 
   func ruleProviders() async throws -> [RuleProvider] {
     let data = try await data(for: request(path: "/providers/rules"))
-    let object = (try JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
+    let object = try (JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
     let providers = object["providers"] as? [String: Any] ?? object
     return providers.compactMap { name, value in
       guard let provider = value as? [String: Any] else { return nil }
@@ -259,10 +259,10 @@ struct MihomoAPIClient: Sendable {
         path: apiPath("proxies", proxy, "delay"),
         queryItems: [
           URLQueryItem(name: "url", value: testURL.absoluteString),
-          URLQueryItem(name: "timeout", value: String(timeout))
+          URLQueryItem(name: "timeout", value: String(timeout)),
         ]
       ))
-    } catch ClientError.httpStatus(let status) where status == 503 || status == 504 {
+    } catch let ClientError.httpStatus(status) where status == 503 || status == 504 {
       // Mihomo uses 503/504 when the controller itself is reachable but the
       // selected node or probe target cannot complete the delay check. Keep
       // those distinct from controller-unavailable failures without masking
@@ -391,7 +391,7 @@ struct MihomoAPIClient: Sendable {
               @unknown default:
                 data = Data()
               }
-              continuation.yield(try decode(data))
+              try continuation.yield(decode(data))
               receiveNext()
             } catch {
               continuation.finish(throwing: error)
@@ -562,7 +562,8 @@ struct MihomoAPIClient: Sendable {
         return value
       }
       if let matchingKey = object.keys.first(where: { $0.caseInsensitiveCompare(key) == .orderedSame }),
-         let value = object[matchingKey] as? [String: Any] {
+         let value = object[matchingKey] as? [String: Any]
+      {
         return value
       }
     }

--- a/ClashMax/Services/NetworkEnvironmentMonitor.swift
+++ b/ClashMax/Services/NetworkEnvironmentMonitor.swift
@@ -72,7 +72,7 @@ final class NetworkEnvironmentMonitor: NetworkEnvironmentMonitoring, @unchecked 
     self.currentNetworkProvider = currentNetworkProvider
     self.wiFiClient = wiFiClient
     var continuation: AsyncStream<NetworkEnvironmentEvent>.Continuation!
-    self.stream = AsyncStream { continuation = $0 }
+    stream = AsyncStream { continuation = $0 }
     self.continuation = continuation
   }
 

--- a/ClashMax/Services/NetworkExtensionController.swift
+++ b/ClashMax/Services/NetworkExtensionController.swift
@@ -50,7 +50,7 @@ struct NetworkExtensionRuntimeConfiguration: Equatable, Sendable {
       "dnsFakeIPEnabled": dnsFakeIPEnabled,
       "systemDNSOverrideEnabled": systemDNSOverrideEnabled,
       "systemDNSServers": systemDNSServers,
-      "systemDNSOverrideApplied": systemDNSOverrideApplied
+      "systemDNSOverrideApplied": systemDNSOverrideApplied,
     ]
   }
 }
@@ -356,7 +356,7 @@ final class NetworkExtensionController {
     self.systemExtensionRequester = systemExtensionRequester
     self.transparentProxyManager = transparentProxyManager
     self.launchServicesRegistrar = launchServicesRegistrar
-    self.diagnosticsStore = diagnosticsURL.map { NetworkExtensionDiagnosticsFileStore(fileURL: $0) } ?? Self.defaultDiagnosticsStore()
+    diagnosticsStore = diagnosticsURL.map { NetworkExtensionDiagnosticsFileStore(fileURL: $0) } ?? Self.defaultDiagnosticsStore()
   }
 
   private static func defaultDiagnosticsStore() -> NetworkExtensionDiagnosticsFileStore {
@@ -468,7 +468,7 @@ final class NetworkExtensionController {
         throw error
       }
     } catch {
-      vpnStatus = (try? await transparentProxyManager.status(
+      vpnStatus = await (try? transparentProxyManager.status(
         forProviderBundleIdentifier: configuration.providerBundleIdentifier
       )) ?? .disconnected
       let message = UserFacingError.message(for: error)
@@ -522,7 +522,7 @@ final class NetworkExtensionController {
     let candidates = [
       Self.networkExtensionsSettingsURL,
       URL(string: "x-apple.systempreferences:com.apple.LoginItems-Settings.extension"),
-      URL(fileURLWithPath: "/System/Applications/System Settings.app")
+      URL(fileURLWithPath: "/System/Applications/System Settings.app"),
     ].compactMap(\.self)
 
     for url in candidates where NSWorkspace.shared.open(url) {
@@ -746,8 +746,8 @@ final class LaunchServicesAppRegistrar: LaunchServicesRegistering {
         userInfo: [
           NSLocalizedDescriptionKey: [
             "Could not refresh LaunchServices registration for /Applications/ClashMax.app.",
-            output
-          ].filter { !$0.isEmpty }.joined(separator: " ")
+            output,
+          ].filter { !$0.isEmpty }.joined(separator: " "),
         ]
       )
     }
@@ -787,7 +787,7 @@ final class NETransparentProxyManagerAdapter: TransparentProxyManaging {
       "dnsFakeIPEnabled": NSNumber(value: configuration.dnsFakeIPEnabled),
       "systemDNSOverrideEnabled": NSNumber(value: configuration.systemDNSOverrideEnabled),
       "systemDNSServers": configuration.systemDNSServers as NSArray,
-      "systemDNSOverrideApplied": NSNumber(value: configuration.systemDNSOverrideApplied)
+      "systemDNSOverrideApplied": NSNumber(value: configuration.systemDNSOverrideApplied),
     ])
     return try await waitForStartResult(manager)
   }

--- a/ClashMax/Services/ProfileDiskIO.swift
+++ b/ClashMax/Services/ProfileDiskIO.swift
@@ -241,9 +241,9 @@ actor OutboundProxyEndpointStore {
   ) async throws -> OutboundProxyEndpointStoreRollbackSnapshot {
     try await withTransactionLock {
       let manifest = try await loadManifest()
-      return OutboundProxyEndpointStoreRollbackSnapshot(
+      return try OutboundProxyEndpointStoreRollbackSnapshot(
         manifest: manifest,
-        passwords: try passwordSnapshots(
+        passwords: passwordSnapshots(
           for: manifest.endpoints.map(\.id) + additionalAffectedEndpointIDs
         )
       )
@@ -313,9 +313,9 @@ actor OutboundProxyEndpointStore {
         restoredEndpoints.append((originalID: originalID, endpoint: restoredEndpoint))
       }
 
-      let rollbackSnapshot = OutboundProxyEndpointStoreRollbackSnapshot(
+      let rollbackSnapshot = try OutboundProxyEndpointStoreRollbackSnapshot(
         manifest: currentManifest,
-        passwords: try passwordSnapshots(
+        passwords: passwordSnapshots(
           for: currentManifest.endpoints.map(\.id) + restoredEndpoints.map(\.endpoint.id)
         )
       )
@@ -400,7 +400,7 @@ actor OutboundProxyEndpointStore {
           OutboundProxyEndpointPasswordSnapshot(
             endpointID: endpoint.id,
             password: previousPassword
-          )
+          ),
         ],
         manifest: previousManifest,
         restoreManifest: true
@@ -441,7 +441,7 @@ actor OutboundProxyEndpointStore {
           OutboundProxyEndpointPasswordSnapshot(
             endpointID: endpoint.id,
             password: oldPassword
-          )
+          ),
         ],
         manifest: previousManifest,
         restoreManifest: true
@@ -471,7 +471,7 @@ actor OutboundProxyEndpointStore {
           OutboundProxyEndpointPasswordSnapshot(
             endpointID: id,
             password: oldPassword
-          )
+          ),
         ],
         manifest: previousManifest,
         restoreManifest: true
@@ -684,10 +684,10 @@ actor OutboundProxyEndpointStore {
     var seen = Set<UUID>()
     var snapshots: [OutboundProxyEndpointPasswordSnapshot] = []
     for endpointID in endpointIDs where seen.insert(endpointID).inserted {
-      snapshots.append(
+      try snapshots.append(
         OutboundProxyEndpointPasswordSnapshot(
           endpointID: endpointID,
-          password: try secretStore.load(account: Self.passwordAccount(for: endpointID))
+          password: secretStore.load(account: Self.passwordAccount(for: endpointID))
         )
       )
     }

--- a/ClashMax/Services/ProxyPortReadinessProbe.swift
+++ b/ClashMax/Services/ProxyPortReadinessProbe.swift
@@ -74,7 +74,7 @@ struct SocksProxyReadinessProbe: ProxyPortReadinessProbing {
     }.value
   }
 
-  nonisolated private static func performGreeting(host: String, port: Int, timeout: TimeInterval) throws {
+  private nonisolated static func performGreeting(host: String, port: Int, timeout: TimeInterval) throws {
     var hints = addrinfo()
     hints.ai_family = AF_UNSPEC
     hints.ai_socktype = SOCK_STREAM
@@ -102,7 +102,7 @@ struct SocksProxyReadinessProbe: ProxyPortReadinessProbing {
     throw lastError ?? AppError.coreNotReady("Could not connect to mixed-port.")
   }
 
-  nonisolated private static func performConnect(host: String, port: Int, timeout: TimeInterval) throws {
+  private nonisolated static func performConnect(host: String, port: Int, timeout: TimeInterval) throws {
     var hints = addrinfo()
     hints.ai_family = AF_UNSPEC
     hints.ai_socktype = SOCK_STREAM
@@ -131,7 +131,7 @@ struct SocksProxyReadinessProbe: ProxyPortReadinessProbing {
     throw lastError ?? AppError.coreNotReady("Could not connect to TCP listener.")
   }
 
-  nonisolated private static func connectAndVerifySOCKS(candidate: UnsafeMutablePointer<addrinfo>, timeout: TimeInterval) throws {
+  private nonisolated static func connectAndVerifySOCKS(candidate: UnsafeMutablePointer<addrinfo>, timeout: TimeInterval) throws {
     let descriptor = try connect(candidate: candidate, timeout: timeout)
     defer { close(descriptor) }
 
@@ -167,7 +167,7 @@ struct SocksProxyReadinessProbe: ProxyPortReadinessProbing {
     }
   }
 
-  nonisolated private static func connect(candidate: UnsafeMutablePointer<addrinfo>, timeout: TimeInterval) throws -> Int32 {
+  private nonisolated static func connect(candidate: UnsafeMutablePointer<addrinfo>, timeout: TimeInterval) throws -> Int32 {
     let address = candidate.pointee
     let descriptor = socket(address.ai_family, address.ai_socktype, address.ai_protocol)
     guard descriptor >= 0 else {
@@ -188,7 +188,7 @@ struct SocksProxyReadinessProbe: ProxyPortReadinessProbing {
     return descriptor
   }
 
-  nonisolated private static func setTimeout(_ timeout: TimeInterval, descriptor: Int32, option: Int32) {
+  private nonisolated static func setTimeout(_ timeout: TimeInterval, descriptor: Int32, option: Int32) {
     let seconds = Int(timeout)
     let microseconds = Int((timeout - TimeInterval(seconds)) * 1_000_000)
     var value = timeval(tv_sec: seconds, tv_usec: Int32(microseconds))

--- a/ClashMax/Services/PublicIPInfoClient.swift
+++ b/ClashMax/Services/PublicIPInfoClient.swift
@@ -104,7 +104,7 @@ extension PublicIPInfoClient.Provider {
     provider("ipapi.is", "https://api.ipapi.is/"),
     provider("ipwho.is", "https://ipwho.is/"),
     provider("skk cf-geoip", "https://ip.api.skk.moe/cf-geoip"),
-    provider("geojs", "https://get.geojs.io/v1/ip/geo.json")
+    provider("geojs", "https://get.geojs.io/v1/ip/geo.json"),
   ]
 
   private static func provider(_ name: String, _ urlString: String) -> PublicIPInfoClient.Provider {
@@ -136,47 +136,47 @@ private enum PublicIPInfoMapper {
       ipAddress: ip,
       countryCode: firstString([
         string(in: object, keys: ["country_code", "countryCode", "countryCodeAlpha2"]),
-        string(in: location, keys: ["country_code", "countryCode"])
+        string(in: location, keys: ["country_code", "countryCode"]),
       ]),
       countryName: firstString([
         string(in: object, keys: ["country", "country_name", "countryName"]),
-        string(in: location, keys: ["country", "country_name"])
+        string(in: location, keys: ["country", "country_name"]),
       ]),
       region: firstString([
         string(in: object, keys: ["region", "regionName", "state"]),
-        string(in: location, keys: ["region", "regionName", "state"])
+        string(in: location, keys: ["region", "regionName", "state"]),
       ]),
       city: firstString([
         string(in: object, keys: ["city"]),
-        string(in: location, keys: ["city"])
+        string(in: location, keys: ["city"]),
       ]),
       asn: normalizedASN(firstString([
         string(in: object, keys: ["asn", "as"]),
         string(in: connection, keys: ["asn"]),
-        string(in: asnObject, keys: ["asn", "number"])
+        string(in: asnObject, keys: ["asn", "number"]),
       ])),
       isp: firstString([
         string(in: object, keys: ["isp"]),
         string(in: connection, keys: ["isp"]),
-        string(in: asnObject, keys: ["isp"])
+        string(in: asnObject, keys: ["isp"]),
       ]),
       organization: firstString([
         string(in: object, keys: ["organization", "org", "asOrganization"]),
         string(in: connection, keys: ["org", "organization"]),
-        string(in: asnObject, keys: ["org", "organization", "name"])
+        string(in: asnObject, keys: ["org", "organization", "name"]),
       ]),
       timezone: firstString([
         string(in: object, keys: ["timezone", "time_zone"]),
         string(in: timezoneObject, keys: ["id", "name"]),
-        string(in: location, keys: ["timezone", "time_zone"])
+        string(in: location, keys: ["timezone", "time_zone"]),
       ]),
       latitude: firstDouble([
         double(in: object, keys: ["latitude", "lat"]),
-        double(in: location, keys: ["latitude", "lat"])
+        double(in: location, keys: ["latitude", "lat"]),
       ]),
       longitude: firstDouble([
         double(in: object, keys: ["longitude", "lon", "lng"]),
-        double(in: location, keys: ["longitude", "lon", "lng"])
+        double(in: location, keys: ["longitude", "lon", "lng"]),
       ]),
       sourceName: sourceName,
       fetchedAt: fetchedAt
@@ -214,7 +214,8 @@ private enum PublicIPInfoMapper {
         return value.doubleValue
       }
       if let value = object[key] as? String,
-         let parsed = Double(value.trimmingCharacters(in: .whitespacesAndNewlines)) {
+         let parsed = Double(value.trimmingCharacters(in: .whitespacesAndNewlines))
+      {
         return parsed
       }
     }
@@ -222,11 +223,11 @@ private enum PublicIPInfoMapper {
   }
 
   private static func firstString(_ values: [String?]) -> String? {
-    values.compactMap { $0 }.first
+    values.compactMap(\.self).first
   }
 
   private static func firstDouble(_ values: [Double?]) -> Double? {
-    values.compactMap { $0 }.first
+    values.compactMap(\.self).first
   }
 
   private static func normalizedASN(_ value: String?) -> String? {

--- a/ClashMax/Services/RuntimeConfigMaterializer.swift
+++ b/ClashMax/Services/RuntimeConfigMaterializer.swift
@@ -10,7 +10,7 @@ struct RuntimeConfigMaterializationRequest: Sendable {
   var options: RuntimeConfigOptions = .default
   var protectedArtifactURLs: [URL] = []
   var retainedGenerationCount: Int = 2
-  var sideLoadedProviderContentPath: String? = nil
+  var sideLoadedProviderContentPath: String?
 }
 
 struct RuntimeConfigMaterializationResult: Sendable, Equatable {
@@ -18,7 +18,7 @@ struct RuntimeConfigMaterializationResult: Sendable, Equatable {
   var providerContentURL: URL?
 
   var artifactURLs: [URL] {
-    [runtimeConfigURL] + [providerContentURL].compactMap { $0 }
+    [runtimeConfigURL] + [providerContentURL].compactMap(\.self)
   }
 }
 

--- a/ClashMax/Services/SubscriptionFetcher.swift
+++ b/ClashMax/Services/SubscriptionFetcher.swift
@@ -522,7 +522,7 @@ struct SubscriptionFetcher {
     usesProfileUpstream: Bool,
     requestHeaders: [SubscriptionHeaderDiagnostic]
   ) -> SubscriptionFetchError {
-    return SubscriptionFetchError(
+    SubscriptionFetchError(
       kind: Self.failureKind(for: error),
       message: usesProfileUpstream
         ? "Subscription fetch through the profile upstream proxy failed."
@@ -701,7 +701,7 @@ struct SubscriptionFetcher {
       "tokens",
       "profile",
       "profiles",
-      "download"
+      "download",
     ].contains(normalized)
   }
 
@@ -797,7 +797,7 @@ struct SubscriptionFetcher {
     guard !trimmed.isEmpty else { return nil }
     let sensitiveValues = [
       resolvedEndpoint.endpoint.authentication?.username,
-      resolvedEndpoint.password
+      resolvedEndpoint.password,
     ].compactMap { value -> String? in
       guard let value else { return nil }
       let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -892,7 +892,8 @@ struct SubscriptionFetcher {
   private func decodedString(from data: Data, response: HTTPURLResponse) -> (source: String, decodedCharset: String)? {
     var encodings: [(String.Encoding, String)] = []
     if let contentType = response.value(forHTTPHeaderField: "Content-Type"),
-       let declaredEncoding = encoding(fromContentType: contentType) {
+       let declaredEncoding = encoding(fromContentType: contentType)
+    {
       encodings.append(declaredEncoding)
     }
     encodings.append((.utf8, "utf-8"))
@@ -972,7 +973,8 @@ struct SubscriptionFetcher {
     if lowercased.hasPrefix("<!doctype html") ||
       lowercased.hasPrefix("<html") ||
       lowercased.contains("<title>") ||
-      lowercased.contains("<form") {
+      lowercased.contains("<form")
+    {
       return true
     }
 
@@ -1026,7 +1028,7 @@ private final class SubscriptionSessionDelegate: NSObject, URLSessionTaskDelegat
     guard
       allowsInsecureTLS,
       challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
-          let trust = challenge.protectionSpace.serverTrust
+      let trust = challenge.protectionSpace.serverTrust
     else {
       completionHandler(.performDefaultHandling, nil)
       return
@@ -1056,7 +1058,7 @@ private final class SubscriptionSessionDelegate: NSObject, URLSessionTaskDelegat
     let supportedMethods = [
       NSURLAuthenticationMethodDefault,
       NSURLAuthenticationMethodHTTPBasic,
-      NSURLAuthenticationMethodHTTPDigest
+      NSURLAuthenticationMethodHTTPDigest,
     ]
     guard
       challenge.protectionSpace.isProxy(),
@@ -1083,7 +1085,7 @@ private func proxyDictionary(
   case .direct:
     return [
       kCFNetworkProxiesHTTPEnable as String: false,
-      kCFNetworkProxiesHTTPSEnable as String: false
+      kCFNetworkProxiesHTTPSEnable as String: false,
     ]
   case .localClashProxy:
     return [
@@ -1092,7 +1094,7 @@ private func proxyDictionary(
       kCFNetworkProxiesHTTPPort as String: options.localProxyPort,
       kCFNetworkProxiesHTTPSEnable as String: true,
       kCFNetworkProxiesHTTPSProxy as String: options.localProxyHost,
-      kCFNetworkProxiesHTTPSPort as String: options.localProxyPort
+      kCFNetworkProxiesHTTPSPort as String: options.localProxyPort,
     ]
   case .systemProxy:
     return nil

--- a/ClashMax/Services/SystemProxyController.swift
+++ b/ClashMax/Services/SystemProxyController.swift
@@ -205,8 +205,8 @@ final class SystemProxyController: @unchecked Sendable {
     self.commandRunner = commandRunner
     self.snapshotDefaults = snapshotDefaults
     self.snapshotDefaultsKey = snapshotDefaultsKey
-    self.snapshots = Self.loadPersistedSnapshots(defaults: snapshotDefaults, key: snapshotDefaultsKey)
-    self.dnsSnapshots = Self.loadPersistedDNSSnapshots(defaults: snapshotDefaults, key: Self.persistedDNSSnapshotsDefaultsKey)
+    snapshots = Self.loadPersistedSnapshots(defaults: snapshotDefaults, key: snapshotDefaultsKey)
+    dnsSnapshots = Self.loadPersistedDNSSnapshots(defaults: snapshotDefaults, key: Self.persistedDNSSnapshotsDefaultsKey)
   }
 
   func apply(host: String, port: Int, bypassDomains: [String] = SystemProxyController.defaultBypassDomains) async throws {
@@ -604,16 +604,16 @@ final class SystemProxyController: @unchecked Sendable {
   }
 
   private func snapshot(for service: String) async throws -> ServiceProxySnapshot {
-    ServiceProxySnapshot(
-      web: ProxyState(output: try await commandRunner.run("/usr/sbin/networksetup", ["-getwebproxy", service])),
-      secureWeb: ProxyState(output: try await commandRunner.run("/usr/sbin/networksetup", ["-getsecurewebproxy", service])),
-      socks: ProxyState(output: try await commandRunner.run("/usr/sbin/networksetup", ["-getsocksfirewallproxy", service])),
-      bypassDomains: ProxyBypassDomains(output: try await commandRunner.run("/usr/sbin/networksetup", ["-getproxybypassdomains", service])).domains
+    try await ServiceProxySnapshot(
+      web: ProxyState(output: commandRunner.run("/usr/sbin/networksetup", ["-getwebproxy", service])),
+      secureWeb: ProxyState(output: commandRunner.run("/usr/sbin/networksetup", ["-getsecurewebproxy", service])),
+      socks: ProxyState(output: commandRunner.run("/usr/sbin/networksetup", ["-getsocksfirewallproxy", service])),
+      bypassDomains: ProxyBypassDomains(output: commandRunner.run("/usr/sbin/networksetup", ["-getproxybypassdomains", service])).domains
     )
   }
 
   private func dnsSnapshot(for service: String) async throws -> ServiceDNSSnapshot {
-    ServiceDNSSnapshot(output: try await commandRunner.run("/usr/sbin/networksetup", ["-getdnsservers", service]))
+    try await ServiceDNSSnapshot(output: commandRunner.run("/usr/sbin/networksetup", ["-getdnsservers", service]))
   }
 
   private func restore(_ state: ProxyState, service: String, kind: ProxyKind) async throws {
@@ -782,7 +782,7 @@ final class SystemProxyController: @unchecked Sendable {
   }
 }
 
-private struct DefaultRouteInterfaces {
+private enum DefaultRouteInterfaces {
   static func parse(_ output: String) -> Set<String> {
     var interfaces = Set<String>()
     for rawLine in output.split(separator: "\n") {
@@ -839,7 +839,7 @@ private struct OrderedNetworkService {
   }
 }
 
-private struct ActiveNetworkInterfaces {
+private enum ActiveNetworkInterfaces {
   static func parse(_ output: String) -> Set<String> {
     var interfaces = Set<String>()
     for rawLine in output.split(separator: "\n") {
@@ -1098,7 +1098,7 @@ struct ProcessCommandRunner: CommandRunning {
           domain: "ClashMax.CommandRunner",
           code: Int(ETIMEDOUT),
           userInfo: [
-            NSLocalizedDescriptionKey: "Command timed out after \(timeout)s: \(command)\(output.isEmpty ? "" : "\n\(output)")"
+            NSLocalizedDescriptionKey: "Command timed out after \(timeout)s: \(command)\(output.isEmpty ? "" : "\n\(output)")",
           ]
         )
       },
@@ -1134,7 +1134,7 @@ struct ProcessCommandRunner: CommandRunning {
       domain: "ClashMax.CommandRunner",
       code: Int(EPERM),
       userInfo: [
-        NSLocalizedDescriptionKey: "Refusing to run mutating networksetup command inside XCTest: \(command). Inject a test CommandRunning double instead."
+        NSLocalizedDescriptionKey: "Refusing to run mutating networksetup command inside XCTest: \(command). Inject a test CommandRunning double instead.",
       ]
     )
   }

--- a/ClashMax/Services/TunRuntimeInspector.swift
+++ b/ClashMax/Services/TunRuntimeInspector.swift
@@ -140,21 +140,21 @@ struct TunRuntimeInspector: TunRuntimeInspecting {
   }
 
   func inspect(_ configuration: TunRuntimeInspectionConfiguration) async -> TunDiagnosticsSnapshot {
-    var checks: [TunDiagnosticCheck] = [
-      await controllerCheck(configuration),
-      helperPIDCheck(configuration)
+    var checks: [TunDiagnosticCheck] = await [
+      controllerCheck(configuration),
+      helperPIDCheck(configuration),
     ]
 
-    checks.append(await interfaceCheck(configuration))
-    checks.append(await defaultRouteCheck(configuration))
-    checks.append(await routeExcludeCheck(configuration))
+    await checks.append(interfaceCheck(configuration))
+    await checks.append(defaultRouteCheck(configuration))
+    await checks.append(routeExcludeCheck(configuration))
     checks.append(systemProxyCheck(configuration))
     checks.append(systemDNSCheck(configuration))
-    checks.append(await dnsHijackCheck(configuration))
+    await checks.append(dnsHijackCheck(configuration))
 
     if configuration.includeExternal {
-      checks.append(await externalTCPCheck())
-      checks.append(await externalUDPCheck())
+      await checks.append(externalTCPCheck())
+      await checks.append(externalUDPCheck())
     } else {
       checks.append(TunDiagnosticCheck(
         id: "external-tcp",
@@ -201,7 +201,7 @@ struct TunRuntimeInspector: TunRuntimeInspecting {
       status: .info,
       message: "\(route.message) Live TCP and UDP probes still reached the network, so traffic is flowing.",
       detail: [route.detail, "external TCP and UDP probes passed"]
-        .compactMap { $0 }
+        .compactMap(\.self)
         .joined(separator: " · ")
     )
     return downgraded
@@ -236,7 +236,7 @@ struct TunRuntimeInspector: TunRuntimeInspecting {
             "2",
             "-H",
             authorizationHeader + configuration.api.secret,
-            versionURL.absoluteString
+            versionURL.absoluteString,
           ],
           displayDescription: [
             Command.curl,
@@ -245,7 +245,7 @@ struct TunRuntimeInspector: TunRuntimeInspecting {
             "2",
             "-H",
             authorizationHeader + StructuredLogRedactor.placeholder,
-            versionURL.absoluteString
+            versionURL.absoluteString,
           ].joined(separator: " ")
         )
       )
@@ -596,7 +596,7 @@ struct TunRuntimeInspector: TunRuntimeInspecting {
           "%{http_code}",
           "--max-time",
           "5",
-          AppConstants.defaultDelayTestURL.absoluteString
+          AppConstants.defaultDelayTestURL.absoluteString,
         ]
       )
       let statusCode = Int(output.trimmingCharacters(in: .whitespacesAndNewlines)) ?? 0

--- a/ClashMax/Services/TunnelHelperClient.swift
+++ b/ClashMax/Services/TunnelHelperClient.swift
@@ -681,11 +681,10 @@ final class TunnelHelperClient {
     }
 
     automaticBootstrapRepairFingerprint = fingerprint
-    let repairedState = try await reregisterEnabledHelper(
+    return try await reregisterEnabledHelper(
       fingerprint: fingerprint,
       openSystemSettingsWhenApprovalRequired: openSystemSettingsWhenApprovalRequired
     )
-    return repairedState
   }
 
   private func reregisterEnabledHelper(
@@ -936,7 +935,7 @@ final class ContinuationBox<Value: Sendable>: @unchecked Sendable {
     if let pendingResult {
       resultToResume = pendingResult
       didAttach = false
-      if shouldRunPendingCleanup && !cleanupHasRun {
+      if shouldRunPendingCleanup, !cleanupHasRun {
         cleanupToRun = cleanup
         cleanupHasRun = true
       } else {
@@ -977,15 +976,15 @@ final class ContinuationBox<Value: Sendable>: @unchecked Sendable {
     }
     pendingResult = result
     shouldRunPendingCleanup = runCleanup
-    continuationToResume = self.continuation
+    continuationToResume = continuation
     if continuationToResume != nil, runCleanup, !cleanupHasRun {
-      cleanupToRun = self.cleanup
+      cleanupToRun = cleanup
       cleanupHasRun = true
     } else {
       cleanupToRun = nil
     }
-    self.continuation = nil
-    self.cleanup = nil
+    continuation = nil
+    cleanup = nil
     lock.unlock()
 
     if let continuationToResume {

--- a/ClashMax/Services/WiFiNetworkInfo.swift
+++ b/ClashMax/Services/WiFiNetworkInfo.swift
@@ -276,7 +276,7 @@ final class WiFiLocationAuthorization {
     let candidates = [
       URL(string: "x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension?Privacy_LocationServices"),
       URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_LocationServices"),
-      URL(fileURLWithPath: "/System/Applications/System Settings.app")
+      URL(fileURLWithPath: "/System/Applications/System Settings.app"),
     ].compactMap(\.self)
 
     for url in candidates where NSWorkspace.shared.open(url) {

--- a/ClashMax/Stores/AppModel.swift
+++ b/ClashMax/Stores/AppModel.swift
@@ -1,8 +1,8 @@
 import AppKit
 import Foundation
-@preconcurrency import UserNotifications
 import ServiceManagement
 import UniformTypeIdentifiers
+@preconcurrency import UserNotifications
 
 private enum AppStartupAbort: Error {
   case waitingForTunHelper
@@ -81,7 +81,6 @@ private struct RuntimeStopResult {
     }
     return nil
   }
-
 }
 
 private struct NetworkExtensionStopCleanupResult {
@@ -94,7 +93,7 @@ private extension TunDiagnosticsSnapshot {
     "interface",
     "default-route",
     "route-exclude",
-    "dns-hijack"
+    "dns-hijack",
   ]
 
   var repairableRoutingIssue: TunDiagnosticCheck? {
@@ -200,27 +199,27 @@ private extension SystemDNSOverrideState {
   }
 }
 
-  struct AppNotice: Equatable {
-    enum Tone: Equatable {
-      case info
-      case success
-      case warning
-    }
+struct AppNotice: Equatable {
+  enum Tone: Equatable {
+    case info
+    case success
+    case warning
+  }
 
   var message: String
   var tone: Tone
 
   var symbolName: String {
-      switch tone {
-      case .info:
-        return "info.circle.fill"
-      case .success:
-        return "checkmark.circle.fill"
-      case .warning:
-        return "exclamationmark.triangle.fill"
-      }
+    switch tone {
+    case .info:
+      return "info.circle.fill"
+    case .success:
+      return "checkmark.circle.fill"
+    case .warning:
+      return "exclamationmark.triangle.fill"
     }
   }
+}
 
 struct InitialTunHelperPrompt: Equatable {
   enum PrimaryAction: Equatable {
@@ -248,7 +247,7 @@ struct InitialTunHelperPrompt: Equatable {
 
   var primaryButtonTitle: String {
     switch stage {
-    case .relocate(let issue):
+    case let .relocate(issue):
       return issue.allowsAutomaticRelocation
         ? String(localized: "Move to Applications")
         : String(localized: "Show in Finder")
@@ -294,9 +293,9 @@ struct RuntimeDiagnosticsReport: Equatable, Sendable {
   var lastError: String?
   var recentLogs: [String]
   var helperLogs: [String]
-  var publicIPInfo: PublicIPInfo? = nil
+  var publicIPInfo: PublicIPInfo?
   var probeHost: String = ""
-  var proxyEffect: ProxyEffectDiagnosticsSnapshot? = nil
+  var proxyEffect: ProxyEffectDiagnosticsSnapshot?
 
   var plainText: String {
     let lines = rawLines().map(redacted)
@@ -570,67 +569,83 @@ final class AppModel {
     get { settings.overrides }
     set { settings.overrides = newValue }
   }
+
   var proxyRoutingMode: ProxyRoutingMode {
     get { settings.proxyRoutingMode }
     set { settings.proxyRoutingMode = newValue }
   }
+
   var systemProxySettings: SystemProxySettings {
     get { settings.systemProxySettings }
     set { settings.systemProxySettings = newValue }
   }
+
   var ipv6Enabled: Bool {
     get { settings.ipv6Enabled }
     set { setIPv6Enabled(newValue) }
   }
+
   var tunSettings: TunSettings {
     get { settings.tunSettings }
     set { settings.tunSettings = newValue }
   }
+
   var networkExtensionRoutingSettings: NetworkExtensionRoutingSettings {
     get { settings.networkExtensionRoutingSettings }
     set { settings.networkExtensionRoutingSettings = newValue }
   }
+
   var ruleOverlaySettings: RuleOverlaySettings {
     get { settings.ruleOverlaySettings }
     set { settings.ruleOverlaySettings = newValue }
   }
+
   var delayTestSettings: DelayTestSettings {
     get { settings.delayTestSettings }
     set { settings.delayTestSettings = newValue }
   }
+
   var proxyPageSettings: ProxyPageSettings {
     get { settings.proxyPageSettings }
     set { settings.proxyPageSettings = newValue }
   }
+
   var appTheme: AppTheme {
     get { settings.appTheme }
     set { settings.appTheme = newValue }
   }
+
   var externalControllerSettings: ExternalControllerSettings {
     get { settings.externalControllerSettings }
     set { settings.externalControllerSettings = newValue }
   }
+
   var menuBarPinnedGroupSettings: MenuBarPinnedGroupSettings {
     get { settings.menuBarPinnedGroupSettings }
     set { settings.menuBarPinnedGroupSettings = newValue }
   }
+
   var globalShortcutSettings: GlobalShortcutSettings {
     get { settings.globalShortcutSettings }
     set { settings.globalShortcutSettings = newValue }
   }
+
   var externalDashboardProfiles: [ExternalDashboardProfile] {
     get { settings.externalDashboardProfiles }
     set { settings.externalDashboardProfiles = newValue }
   }
+
   var networkPolicySettings: NetworkPolicySettings {
     get { settings.networkPolicySettings }
     set { settings.networkPolicySettings = newValue }
   }
+
   var launchSettings: LaunchSettings { settings.launchSettings }
   var developerMode: Bool {
     get { settings.developerMode }
     set { setDeveloperMode(newValue) }
   }
+
   /// Log level the user currently has selected in Settings. Log views and the
   /// diagnostics report key their visibility off this so that choosing Debug
   /// actually surfaces debug entries instead of requiring Developer Mode too.
@@ -643,31 +658,37 @@ final class AppModel {
     get { systemProxy.enabled }
     set { systemProxy.enabled = newValue }
   }
+
   var tunEnabled = false
   private(set) var tunHelperPID: Int?
   var networkExtensionEnabled: Bool {
     runtimeOwner == .networkExtension && networkExtensionController.vpnStatus.isActive
   }
+
   var canRepairNetworkExtensionDNS: Bool {
     runtimeOwner == .networkExtension
       || networkExtensionController.vpnStatus.isActive
       || systemProxyController.hasManagedSystemDNSState
   }
+
   var canRepairTunDNS: Bool {
     runtimeOwner == .tunnel
       || tunEnabled
       || tunnelCoreRunning
       || systemProxyController.hasManagedSystemDNSState
   }
+
   /// Whether the last diagnostics pass saw macOS still pointing apps at a loopback proxy the
   /// running runtime does not serve. Gates the visibility of the "disable residual System Proxy"
   /// action, which stays hidden while there is nothing stranded to clean up.
   var hasResidualSystemProxy: Bool {
     !residualSystemProxyEntries.isEmpty
   }
+
   var canDisableResidualSystemProxy: Bool {
     hasResidualSystemProxy && !residualSystemProxyDisableInFlight
   }
+
   var canRepairTunRouting: Bool {
     runtimeOwner == .tunnel
       || tunEnabled
@@ -676,6 +697,7 @@ final class AppModel {
       || tunDiagnostics.primaryIssue != nil
       || systemProxyController.hasManagedSystemDNSState
   }
+
   var tunnelCoreRunning = false
   private(set) var networkExtensionSystemDNSState: SystemDNSOverrideState = .inactive
   private(set) var tunSystemDNSState: SystemDNSOverrideState = .inactive
@@ -696,25 +718,29 @@ final class AppModel {
     get { runtimeData.proxyGroups }
     set { runtimeData.proxyGroups = newValue }
   }
+
   var proxyProviders: [ProxyProvider] {
     get { runtimeData.proxyProviders }
     set { runtimeData.proxyProviders = newValue }
   }
+
   var ruleProviders: [RuleProvider] {
     get { runtimeData.ruleProviders }
     set { runtimeData.ruleProviders = newValue }
   }
+
   var rules: [RuntimeRule] {
     get { runtimeData.rules }
     set { runtimeData.rules = newValue }
   }
+
   var connections: [ConnectionSnapshot] {
     get { runtimeData.connections }
     set { runtimeData.replaceConnections(newValue) }
   }
-  var logs: [LogEntry] {
-    get { runtimeData.logs }
-  }
+
+  var logs: [LogEntry] { runtimeData.logs }
+
   var helperLogs: [String] = []
   private(set) var initialTunHelperPrompt: InitialTunHelperPrompt?
   private(set) var initialTunHelperPromptActionInFlight = false
@@ -724,10 +750,12 @@ final class AppModel {
     get { runtimeData.trafficSample }
     set { runtimeData.trafficSample = newValue }
   }
+
   var trafficHistory: [TrafficSample] {
     get { runtimeData.trafficHistory }
     set { runtimeData.trafficHistory = newValue }
   }
+
   var publicIPInfoState: PublicIPInfoState { publicIP.state }
   private(set) var appNotice: AppNotice?
   private(set) var runtimeSettingsApplyState: RuntimeSettingsApplyState = .idle
@@ -735,6 +763,7 @@ final class AppModel {
   var hasLoadedEffectiveRuntimeConfigForActiveProfile: Bool {
     effectiveRuntimeConfigSnapshotForActiveProfile != nil
   }
+
   private(set) var providerSideLoadPreflightStatus: ProviderSideLoadPreflightStatus = .idle
   private(set) var proxyDelayBatchProgress: ProxyDelayBatchProgress?
   var routingSimulationRequest: RoutingSimulationRequest?
@@ -755,6 +784,7 @@ final class AppModel {
       }
     }
   }
+
   private(set) var lastErrorDetails: String?
 
   func publishSubscriptionFailure(_ error: Error) {
@@ -774,6 +804,7 @@ final class AppModel {
     appNotice = AppNotice(message: message, tone: .warning)
     appendAppLog(level: "warn", message: logMessage ?? message)
   }
+
   private(set) var currentNetwork: WiFiNetworkSnapshot = .notChecked
   var currentNetworkSSID: String? { currentNetwork.ssid }
   private(set) var networkPolicyStatusMessage: String?
@@ -790,14 +821,17 @@ final class AppModel {
     get { proxyPreview.profilePreviewGroups }
     set { proxyPreview.profilePreviewGroups = newValue }
   }
+
   var previewRuntimeActive: Bool {
     get { proxyPreview.previewRuntimeActive }
     set { proxyPreview.previewRuntimeActive = newValue }
   }
+
   var previewSelections: [String: String] {
     get { proxyPreview.previewSelections }
     set { proxyPreview.previewSelections = newValue }
   }
+
   var providerHealthChecksInFlight: Set<ProxyProvider.ID> { runtimeData.providerHealthChecksInFlight }
   var proxyProviderUpdatesInFlight: Set<ProxyProvider.ID> { runtimeData.proxyProviderUpdatesInFlight }
   var ruleProviderUpdatesInFlight: Set<RuleProvider.ID> { runtimeData.ruleProviderUpdatesInFlight }
@@ -1005,7 +1039,7 @@ final class AppModel {
     self.currentNetworkProvider = currentNetworkProvider
     self.networkEnvironmentMonitor = networkEnvironmentMonitor ?? NetworkEnvironmentMonitor(currentNetworkProvider: currentNetworkProvider)
     self.wiFiLocationAuthorization = wiFiLocationAuthorization
-    self.globalShortcutManager = GlobalShortcutManager(registrar: globalShortcutRegistrar ?? KeyboardShortcutsRegistrar())
+    globalShortcutManager = GlobalShortcutManager(registrar: globalShortcutRegistrar ?? KeyboardShortcutsRegistrar())
     self.providerSideLoadPreflightRunner = providerSideLoadPreflightRunner
     self.bundledCoreURLProvider = bundledCoreURLProvider ?? Self.resolveBundledCoreURL
     self.profileStore = profileStore ?? ProfileStore(paths: paths)
@@ -1013,8 +1047,8 @@ final class AppModel {
       ?? OutboundProxyEndpointStore(manifestURL: paths.outboundProxyEndpointManifestURL)
     self.runtimeSnippetLibrary = runtimeSnippetLibrary ?? RuntimeSnippetLibraryStore(paths: paths)
     self.providerAnalytics = providerAnalytics ?? ProviderAnalyticsStore(paths: paths)
-    self.proxyPreview = ProxyPreviewStore(defaults: defaults)
-    self.profileCoordinator = ProfileCoordinator(profileStore: self.profileStore, proxyPreview: self.proxyPreview)
+    proxyPreview = ProxyPreviewStore(defaults: defaults)
+    profileCoordinator = ProfileCoordinator(profileStore: self.profileStore, proxyPreview: proxyPreview)
     self.coreController = coreController
     self.helperClient = helperClient
     self.installLocationInspector = installLocationInspector
@@ -1023,12 +1057,12 @@ final class AppModel {
     self.proxyPortReadinessProbe = proxyPortReadinessProbe
     self.tunRuntimeInspector = tunRuntimeInspector
     self.pingTester = pingTester
-    self.publicIP = PublicIPCoordinator(
+    publicIP = PublicIPCoordinator(
       client: publicIPInfoClient,
       refreshInterval: Self.publicIPRefreshInterval
     )
     self.apiClient = apiClient
-    self.systemProxy = SystemProxyCoordinator(
+    systemProxy = SystemProxyCoordinator(
       controller: systemProxyController ?? SystemProxyController(snapshotDefaults: defaults),
       defaults: defaults
     )
@@ -1043,17 +1077,17 @@ final class AppModel {
       subscriptionFetchOptions: { [weak self] profile in
         guard let self else { return SubscriptionFetchOptions() }
         if let profile {
-          return try await self.subscriptionFetchOptions(for: profile)
+          return try await subscriptionFetchOptions(for: profile)
         }
-        return self.subscriptionFetchOptions
+        return subscriptionFetchOptions
       },
       preflightValidator: { [weak self] in
         guard let self else { return NoopSubscriptionProfilePreflightValidator() }
-        return self.subscriptionPreflightValidator()
+        return subscriptionPreflightValidator()
       },
       reloadActiveRuntimeConfigIfNeeded: { [weak self] profileID, logMessage in
         guard let self else { return }
-        try await self.reloadActiveRuntimeConfigIfNeeded(for: profileID, logMessage: logMessage)
+        try await reloadActiveRuntimeConfigIfNeeded(for: profileID, logMessage: logMessage)
       },
       appendAppLog: { [weak self] level, message in
         self?.appendAppLog(level: level, message: message)
@@ -1066,7 +1100,7 @@ final class AppModel {
       },
       shouldSyncRuntimeAfterProfileChange: { [weak self] in
         guard let self else { return false }
-        return self.isRunning || self.startInFlight
+        return isRunning || startInFlight
       },
       restartRuntime: { [weak self] in
         self?.restart()
@@ -1128,9 +1162,9 @@ final class AppModel {
       Task { @MainActor [weak self] in
         guard let self else { return }
         await self.profileStore.waitForManifestLoad()
-        await self.refreshProfilePreviewAndWait()
-        self.loadPreviewSelectionsForActiveProfile()
-        self.profileCoordinator.rescheduleSubscriptionAutoUpdates()
+        await refreshProfilePreviewAndWait()
+        loadPreviewSelectionsForActiveProfile()
+        profileCoordinator.rescheduleSubscriptionAutoUpdates()
       }
     } else {
       profileCoordinator.rescheduleSubscriptionAutoUpdates()
@@ -1272,7 +1306,8 @@ final class AppModel {
       try await profileStore.updateUpstreamEndpoint(for: currentProfile, endpointID: endpointID)
       do {
         if currentProfile.id == profileStore.activeProfileID,
-           isRunning || previewRuntimeActive {
+           isRunning || previewRuntimeActive
+        {
           try await reloadActiveRuntimeConfigIfNeeded(
             for: currentProfile.id,
             logMessage: "Upstream proxy updated: Mihomo reloaded"
@@ -1347,7 +1382,8 @@ final class AppModel {
       do {
         if references.contains(where: { $0.profileID == profileStore.activeProfileID }),
            isRunning || previewRuntimeActive,
-           let activeProfileID = profileStore.activeProfileID {
+           let activeProfileID = profileStore.activeProfileID
+        {
           try await reloadActiveRuntimeConfigIfNeeded(
             for: activeProfileID,
             logMessage: "Outbound proxy updated: Mihomo reloaded"
@@ -1597,7 +1633,8 @@ final class AppModel {
 
   private var activeNetworkExtensionCoreCrashMessage: String? {
     if case let .crashed(message) = coreController.status,
-       runtimeOwner == .networkExtension || networkExtensionController.vpnStatus.isActive || networkExtensionCoreCrashMessage != nil {
+       runtimeOwner == .networkExtension || networkExtensionController.vpnStatus.isActive || networkExtensionCoreCrashMessage != nil
+    {
       return message
     }
     return networkExtensionCoreCrashMessage
@@ -1620,7 +1657,7 @@ final class AppModel {
   }
 
   var visibleProxyGroups: [ProxyGroup] {
-    if previewRuntimeActive && proxyGroups.isEmpty && !profilePreviewGroups.isEmpty {
+    if previewRuntimeActive, proxyGroups.isEmpty, !profilePreviewGroups.isEmpty {
       return mergedPreviewSelections(into: profilePreviewGroups)
     }
     if isCoreRunning {
@@ -1673,7 +1710,8 @@ final class AppModel {
   /// Uses the host of the most recent public-IP result, falling back to the default provider host.
   var proxyEffectProbeHost: String {
     if let host = publicIPInfoState.info?.sourceHost?.trimmingCharacters(in: .whitespacesAndNewlines),
-       !host.isEmpty {
+       !host.isEmpty
+    {
       return host
     }
     return ProxyEffectDiagnosticsInput.defaultProbeHost
@@ -2012,11 +2050,11 @@ final class AppModel {
         overrides: overrides,
         selectionOverrides: previewSelections,
         runtimeSnippets: runtimeSnippetLibrary.snippets(applyingTo: targetProfile.id),
-        runtimeOptions: try await resolvedRuntimeConfigOptions(
+        runtimeOptions: resolvedRuntimeConfigOptions(
           for: targetProfile,
           baseOptions: currentRoutingRuntimeConfigOptions()
         ),
-        coreURL: try bundledCoreURL()
+        coreURL: bundledCoreURL()
       )
       providerSideLoadPreflightStatus = .succeeded(
         ProviderSideLoadPreflightResult(
@@ -2357,7 +2395,8 @@ final class AppModel {
 
   private func commandURLAction(from url: URL) -> String {
     if let host = url.host(percentEncoded: false)?.trimmingCharacters(in: .whitespacesAndNewlines),
-       !host.isEmpty {
+       !host.isEmpty
+    {
       return host
     }
     return url.pathComponents
@@ -2476,7 +2515,7 @@ final class AppModel {
     let secret = profile.readOnly
       ? nil
       : profile.secretAccount.flatMap { try? externalDashboardSecretStore.load(account: $0) }
-        ?? externalControllerSettings.normalizedSecret
+      ?? externalControllerSettings.normalizedSecret
     return Self.dashboardOpenPlan(
       baseURL: profile.url,
       controllerHost: externalControllerSettings.normalizedHost,
@@ -2568,7 +2607,7 @@ final class AppModel {
     var items = components.queryItems ?? []
     let fixedValues = [
       URLQueryItem(name: "hostname", value: controllerHost),
-      URLQueryItem(name: "port", value: "\(controllerPort)")
+      URLQueryItem(name: "port", value: "\(controllerPort)"),
     ]
     for value in fixedValues {
       items.removeAll { $0.name.caseInsensitiveCompare(value.name) == .orderedSame }
@@ -2936,7 +2975,7 @@ final class AppModel {
       let updated = try await profileCoordinator.updateSubscription(
         profile,
         session: session,
-        fetchOptions: try await subscriptionFetchOptions(for: profile),
+        fetchOptions: subscriptionFetchOptions(for: profile),
         preflightValidator: subscriptionPreflightValidator()
       )
       if updated, profile.id == profileStore.activeProfileID {
@@ -2969,7 +3008,7 @@ final class AppModel {
         url: resolution.url,
         displayNameHint: resolution.displayNameHint,
         session: session,
-        fetchOptions: try await subscriptionFetchOptions(for: profile),
+        fetchOptions: subscriptionFetchOptions(for: profile),
         preflightValidator: subscriptionPreflightValidator()
       )
       if updated {
@@ -3043,7 +3082,7 @@ final class AppModel {
         displayNameHint: resolution.displayNameHint,
         options: options,
         session: session,
-        fetchOptions: try await subscriptionFetchOptions(for: profile, providerOptions: options),
+        fetchOptions: subscriptionFetchOptions(for: profile, providerOptions: options),
         preflightValidator: subscriptionPreflightValidator()
       )
       if updated {
@@ -3234,12 +3273,12 @@ final class AppModel {
       overrides: overrides,
       coreURLProvider: { [weak self] in
         guard let self else { throw AppError.missingBundledCore }
-        return try self.bundledCoreURL()
+        return try bundledCoreURL()
       },
       runtimeSnippetsProvider: { [weak self] profileID in
         guard let self, let profileID else { return [] }
-        await self.runtimeSnippetLibrary.waitForLoad()
-        return self.runtimeSnippetLibrary.snippets(applyingTo: profileID)
+        await runtimeSnippetLibrary.waitForLoad()
+        return runtimeSnippetLibrary.snippets(applyingTo: profileID)
       },
       runtimeEndpointOptionsProvider: { [weak self] profileID in
         if let fixedUpstreamEndpoint {
@@ -3250,11 +3289,11 @@ final class AppModel {
         guard
           let self,
           let profileID,
-          let profile = self.profileStore.profiles.first(where: { $0.id == profileID })
+          let profile = profileStore.profiles.first(where: { $0.id == profileID })
         else {
           return .default
         }
-        return try await self.resolvedRuntimeConfigOptions(for: profile)
+        return try await resolvedRuntimeConfigOptions(for: profile)
       }
     )
   }
@@ -3276,7 +3315,8 @@ final class AppModel {
       || tunLaunchInFlight
       || tunStartAwaitingHelperReply
       || tunHelperStopUnconfirmed
-      || tunHelperPID != nil {
+      || tunHelperPID != nil
+    {
       pendingStartAfterStop = userInitiated
       if !lifecycleStopInFlight {
         beginLifecycleStop(restartAfterStop: userInitiated)
@@ -3306,9 +3346,9 @@ final class AppModel {
     startTask = Task { [weak self] in
       await Task.yield()
       guard let self,
-            self.startTaskID == taskID,
+            startTaskID == taskID,
             !Task.isCancelled else { return }
-      await self.performStart(taskID: taskID)
+      await performStart(taskID: taskID)
     }
   }
 
@@ -3332,28 +3372,28 @@ final class AppModel {
     do {
       try await withTimeout(seconds: Self.startWallClockSeconds) { @Sendable [weak self] in
         guard let self else { return }
-        try await self.runStartSequence(startRequestID: taskID)
+        try await runStartSequence(startRequestID: taskID)
       }
       completedSuccessfully = true
     } catch is CancellationError {
       if !lifecycleStopInFlight {
-        handleStopResult(await stopRuntimeCoordinated())
+        await handleStopResult(stopRuntimeCoordinated())
       }
     } catch AppStartupAbort.waitingForTunHelper {
       guard startTaskID == taskID, !lifecycleStopInFlight else { return }
-      handleStopResult(await stopRuntimeCoordinated())
+      await handleStopResult(stopRuntimeCoordinated())
     } catch let error as OperationTimedOutError {
       guard startTaskID == taskID, !lifecycleStopInFlight else { return }
       publishStartupDiagnostics(level: "error")
       let helperOwnedCore = helperMayHoldCoreOutput
-      handleStopResult(await stopRuntimeCoordinated())
+      await handleStopResult(stopRuntimeCoordinated())
       let diagnostics = await startFailureDiagnostics(helperOwnedCore: helperOwnedCore)
       lastError = "ClashMax could not start within \(Int(error.seconds))s.\(diagnostics.isEmpty ? "" : "\n\(diagnostics)")"
     } catch {
       guard startTaskID == taskID, !lifecycleStopInFlight else { return }
       publishStartupDiagnostics(level: "error")
       let helperOwnedCore = helperMayHoldCoreOutput
-      handleStopResult(await stopRuntimeCoordinated())
+      await handleStopResult(stopRuntimeCoordinated())
       let message = UserFacingError.message(for: error)
       let diagnostics = await startFailureDiagnostics(
         helperOwnedCore: helperOwnedCore,
@@ -3488,7 +3528,7 @@ final class AppModel {
     let coreURL = try bundledCoreURL()
     appendAppLog(level: "info", message: "Runtime config path: \(runtimeConfig.path)")
     appendAppLog(level: "info", message: "Mihomo core path: \(coreURL.path)")
-    let client = MihomoAPIClient(baseURL: try startSnapshot.overrides.endpoint.baseURL, secret: startSnapshot.overrides.secret)
+    let client = try MihomoAPIClient(baseURL: startSnapshot.overrides.endpoint.baseURL, secret: startSnapshot.overrides.secret)
     apiClient = client
     try checkStartRequest(startRequestID)
 
@@ -3872,29 +3912,29 @@ final class AppModel {
           self.runtimeSettingsApplyToken = nil
         }
       }
-      while self.runtimeSettingsApplyToken == token, !Task.isCancelled {
+      while runtimeSettingsApplyToken == token, !Task.isCancelled {
         do {
           try await Task.sleep(nanoseconds: 50_000_000)
         } catch {
           return
         }
-        guard self.runtimeSettingsApplyToken == token, !Task.isCancelled else { return }
-        guard let reason = self.pendingRuntimeSettingsApplyReason else { return }
-        self.pendingRuntimeSettingsApplyReason = nil
-        self.runtimeSettingsApplyState = .applying
+        guard runtimeSettingsApplyToken == token, !Task.isCancelled else { return }
+        guard let reason = pendingRuntimeSettingsApplyReason else { return }
+        pendingRuntimeSettingsApplyReason = nil
+        runtimeSettingsApplyState = .applying
         do {
-          try await self.applyRunningRuntimeSettings(reason: reason)
-          guard self.runtimeSettingsApplyToken == token, !Task.isCancelled else { return }
-          if self.pendingRuntimeSettingsApplyReason == nil {
-            self.runtimeSettingsApplyState = .idle
-            self.lastError = nil
+          try await applyRunningRuntimeSettings(reason: reason)
+          guard runtimeSettingsApplyToken == token, !Task.isCancelled else { return }
+          if pendingRuntimeSettingsApplyReason == nil {
+            runtimeSettingsApplyState = .idle
+            lastError = nil
             return
           } else {
-            self.runtimeSettingsApplyState = .pending
+            runtimeSettingsApplyState = .pending
           }
         } catch is CancellationError {
           return
-        } catch RuntimeSettingsApplyFailure.followUpFailed(let message) {
+        } catch let RuntimeSettingsApplyFailure.followUpFailed(message) {
           guard self.runtimeSettingsApplyToken == token else { return }
           if self.pendingRuntimeSettingsApplyReason != nil {
             self.runtimeSettingsApplyState = .pending
@@ -3907,26 +3947,26 @@ final class AppModel {
           )
           return
         } catch {
-          guard self.runtimeSettingsApplyToken == token else { return }
+          guard runtimeSettingsApplyToken == token else { return }
           let message = UserFacingError.message(for: error)
-          if self.tunHelperStopUnconfirmed {
-            self.runtimeSettingsApplyTask = nil
-            self.runtimeSettingsApplyToken = nil
-            self.pendingRuntimeSettingsApplyReason = nil
-            let stopResult = await self.stopRuntimeCoordinated(.safetyShutdown)
-            self.handleStopResult(stopResult)
-            self.runtimeSettingsApplyState = .failed(message)
-            self.lastError = stopResult.succeeded
+          if tunHelperStopUnconfirmed {
+            runtimeSettingsApplyTask = nil
+            runtimeSettingsApplyToken = nil
+            pendingRuntimeSettingsApplyReason = nil
+            let stopResult = await stopRuntimeCoordinated(.safetyShutdown)
+            handleStopResult(stopResult)
+            runtimeSettingsApplyState = .failed(message)
+            lastError = stopResult.succeeded
               ? "Runtime settings could not be applied after a TUN helper restart, so ClashMax stopped TUN safely: \(message)"
               : "Runtime settings could not be applied and TUN cleanup also failed: \(message)"
             return
           }
-          if self.pendingRuntimeSettingsApplyReason != nil {
-            self.runtimeSettingsApplyState = .pending
+          if pendingRuntimeSettingsApplyReason != nil {
+            runtimeSettingsApplyState = .pending
             continue
           }
-          self.runtimeSettingsApplyState = .failed(message)
-          self.lastError = String(
+          runtimeSettingsApplyState = .failed(message)
+          lastError = String(
             format: String(localized: "Runtime settings saved but could not be applied: %@"),
             message
           )
@@ -3987,8 +4027,9 @@ final class AppModel {
 
     let clientForRuntime: any MihomoAPIControlling
     if let appliedEndpoint = previouslyAppliedEndpoint,
-       appliedEndpoint != target.overrides.endpoint {
-      clientForRuntime = MihomoAPIClient(baseURL: try target.overrides.endpoint.baseURL, secret: target.overrides.secret)
+       appliedEndpoint != target.overrides.endpoint
+    {
+      clientForRuntime = try MihomoAPIClient(baseURL: target.overrides.endpoint.baseURL, secret: target.overrides.secret)
     } else {
       clientForRuntime = currentClient
     }
@@ -4004,7 +4045,8 @@ final class AppModel {
       }
 
       if target.runtimeOwner == .networkExtension,
-         target.networkExtensionRoutingSettings.dnsCaptureEnabled {
+         target.networkExtensionRoutingSettings.dnsCaptureEnabled
+      {
         try await proxyPortReadinessProbe.waitUntilOpen(
           host: NetworkExtensionRoutingSettings.defaultDNSListenHost,
           port: target.networkExtensionRoutingSettings.normalizedDNSListenPort,
@@ -4035,11 +4077,11 @@ final class AppModel {
     do {
       try await withTimeout(seconds: Self.startWallClockSeconds) { @Sendable [weak self] in
         guard let self else { return }
-        try await self.runStartSequence()
+        try await runStartSequence()
       }
     } catch {
       if !lifecycleStopInFlight, stopTask == nil {
-        handleStopResult(await stopRuntimeCoordinated(.settingsApplyRestart))
+        await handleStopResult(stopRuntimeCoordinated(.settingsApplyRestart))
       }
       throw error
     }
@@ -4391,16 +4433,16 @@ final class AppModel {
         }
       }
       guard !Task.isCancelled else { return }
-      await self.applyNetworkPolicyRule(rule, trigger: trigger, matchedSSID: matchedSSID)
+      await applyNetworkPolicyRule(rule, trigger: trigger, matchedSSID: matchedSSID)
     }
   }
 
-    private func applyNetworkPolicyRule(_ rule: NetworkPolicyRule, trigger: String, matchedSSID: String?) async {
-      if let validationError = rule.validationError {
-        networkPolicyStatusMessage = validationError
-        publishWarningNotice(validationError)
-        return
-      }
+  private func applyNetworkPolicyRule(_ rule: NetworkPolicyRule, trigger: String, matchedSSID: String?) async {
+    if let validationError = rule.validationError {
+      networkPolicyStatusMessage = validationError
+      publishWarningNotice(validationError)
+      return
+    }
 
     let automatic = trigger != "manual"
     let policyStartedRuntime = rule.autoStartRuntime && !isRunning && !startInFlight
@@ -4470,7 +4512,7 @@ final class AppModel {
           self.networkPolicyApplyToken = nil
         }
       }
-      await self.restoreNetworkPolicyState(snapshot, reason: reason)
+      await restoreNetworkPolicyState(snapshot, reason: reason)
     }
     return true
   }
@@ -4911,7 +4953,7 @@ final class AppModel {
         lastError = nil
         try await helperClient.unregister()
         tunHelperPID = nil
-        if !tunEnabled && !tunnelCoreRunning {
+        if !tunEnabled, !tunnelCoreRunning {
           tunHelperPreparationState = .idle
         }
         await updateTunHelperStatusDetail()
@@ -4927,7 +4969,7 @@ final class AppModel {
 
   func resetHelperState() {
     helperClient.resetRegistrationState()
-    if !tunEnabled && !tunnelCoreRunning {
+    if !tunEnabled, !tunnelCoreRunning {
       tunHelperPreparationState = .idle
     }
     tunHelperStatusDetail = .unknown
@@ -4946,7 +4988,8 @@ final class AppModel {
       tunHelperPID = detail.pid
       if !tunLaunchInFlight,
          !tunStartAwaitingHelperReply,
-         runtimeOwner != .tunnel || !tunnelCoreRunning || lifecycleStopInFlight || stopTask != nil {
+         runtimeOwner != .tunnel || !tunnelCoreRunning || lifecycleStopInFlight || stopTask != nil
+      {
         // The helper can outlive the app after a crash or forced quit. Preserve
         // that fact so the next Start performs cleanup before launching another
         // helper-owned Mihomo process.
@@ -4956,7 +4999,8 @@ final class AppModel {
               detail.bootstrapped,
               runtimeOwner != .tunnel,
               !tunLaunchInFlight,
-              !tunStartAwaitingHelperReply {
+              !tunStartAwaitingHelperReply
+    {
       // Only an authoritative, protocol-compatible XPC reply can clear a
       // previously uncertain helper stop.
       tunHelperPID = nil
@@ -5278,7 +5322,7 @@ final class AppModel {
     let servedPorts: Set<Int> = [runtimeOverrides.mixedPort]
     tunDiagnosticsTask = Task { @MainActor [weak self] in
       let helperStatus = await self?.liveTunHelperStatus(using: helperClient)
-        ?? (pid: Optional<Int>.none, message: Optional<String>.none)
+        ?? (pid: Int?.none, message: String?.none)
       guard !Task.isCancelled else { return }
       self?.tunHelperPID = helperStatus.pid
       let systemProxyState = await self?.sampleLocalSystemProxyState(servedPorts: servedPorts) ?? .notSampled
@@ -5354,27 +5398,27 @@ final class AppModel {
         let state = try await withTimeout(seconds: 2.5) { @Sendable [helperClient] in
           await helperClient.currentPreparationState()
         }
-        self.applyTunHelperPreparationState(state)
-        await self.updateTunHelperStatusDetail()
-        } catch is OperationTimedOutError {
-          let message = TunnelHelperClient.notBootstrappedMessage
-          self.helperClient.statusMessage = message
-          self.tunHelperPreparationState = .notBootstrapped(message)
-          self.publishWarningNotice(message)
-          self.lastError = nil
-          await self.updateTunHelperStatusDetail()
-          if self.developerMode {
-            self.helperLogs = await self.helperLaunchdDiagnostics()
-          }
-        } catch {
-          let message = UserFacingError.message(for: error)
-          self.helperClient.statusMessage = message
-          self.tunHelperPreparationState = .notBootstrapped(message)
-          self.publishWarningNotice(message)
-          self.lastError = nil
-          await self.updateTunHelperStatusDetail()
-          if self.developerMode {
-            self.helperLogs = await self.helperLaunchdDiagnostics()
+        applyTunHelperPreparationState(state)
+        await updateTunHelperStatusDetail()
+      } catch is OperationTimedOutError {
+        let message = TunnelHelperClient.notBootstrappedMessage
+        helperClient.statusMessage = message
+        tunHelperPreparationState = .notBootstrapped(message)
+        publishWarningNotice(message)
+        lastError = nil
+        await updateTunHelperStatusDetail()
+        if developerMode {
+          helperLogs = await helperLaunchdDiagnostics()
+        }
+      } catch {
+        let message = UserFacingError.message(for: error)
+        helperClient.statusMessage = message
+        tunHelperPreparationState = .notBootstrapped(message)
+        publishWarningNotice(message)
+        lastError = nil
+        await updateTunHelperStatusDetail()
+        if developerMode {
+          helperLogs = await helperLaunchdDiagnostics()
         }
       }
     }
@@ -5387,26 +5431,26 @@ final class AppModel {
         let lines = try await withTimeout(seconds: 4) { @Sendable [helperClient] in
           try await helperClient.recentLogs()
         }
-        self.helperLogs = lines
-        await self.updateTunHelperStatusDetail()
-        } catch is OperationTimedOutError {
-          let message = TunnelHelperClient.notBootstrappedMessage
-          self.helperClient.statusMessage = message
-          self.helperLogs = await self.helperLaunchdDiagnostics()
-          self.publishWarningNotice(message)
-          self.lastError = nil
-          await self.updateTunHelperStatusDetail()
-        } catch {
-          let message = UserFacingError.message(for: error)
-          self.helperClient.statusMessage = message
-          if self.developerMode {
-            self.helperLogs = await self.helperLaunchdDiagnostics()
-          }
-          self.publishWarningNotice(message)
-          self.lastError = nil
-          await self.updateTunHelperStatusDetail()
+        helperLogs = lines
+        await updateTunHelperStatusDetail()
+      } catch is OperationTimedOutError {
+        let message = TunnelHelperClient.notBootstrappedMessage
+        helperClient.statusMessage = message
+        helperLogs = await helperLaunchdDiagnostics()
+        publishWarningNotice(message)
+        lastError = nil
+        await updateTunHelperStatusDetail()
+      } catch {
+        let message = UserFacingError.message(for: error)
+        helperClient.statusMessage = message
+        if developerMode {
+          helperLogs = await helperLaunchdDiagnostics()
         }
+        publishWarningNotice(message)
+        lastError = nil
+        await updateTunHelperStatusDetail()
       }
+    }
   }
 
   private func helperLaunchdDiagnostics() async -> [String] {
@@ -5421,7 +5465,7 @@ final class AppModel {
         "last exit code =",
         "program identifier =",
         "parent bundle version =",
-        "path ="
+        "path =",
       ]
       let lines = output
         .split(whereSeparator: \.isNewline)
@@ -5584,13 +5628,13 @@ final class AppModel {
         }
       } catch is CancellationError {
         return
-        } catch {
-          guard delayTestTokens[taskKey] == token else { return }
-          let message = UserFacingError.message(for: error)
-          applyDelayState(delayState(message: message), to: nodeKey)
-          publishDelayWarning(for: node, in: group, message: message)
-        }
+      } catch {
+        guard delayTestTokens[taskKey] == token else { return }
+        let message = UserFacingError.message(for: error)
+        applyDelayState(delayState(message: message), to: nodeKey)
+        publishDelayWarning(for: node, in: group, message: message)
       }
+    }
   }
 
   private func startProxyDelayBatch(overrideTestURL: URL?) {
@@ -5636,7 +5680,7 @@ final class AppModel {
 
     proxyDelayBatchTask = Task { @MainActor [weak self] in
       guard let self else { return }
-      await self.runProxyDelayBatch(
+      await runProxyDelayBatch(
         items: items,
         apiClient: apiClient,
         settings: settings,
@@ -5694,7 +5738,8 @@ final class AppModel {
         ? .greatestFiniteMagnitude
         : Double(DispatchTime.now().uptimeNanoseconds &- lastFlushNanos) / 1_000_000
       if processedSinceFlush >= Self.proxyDelayBatchFlushCount
-        || elapsedMs >= Self.proxyDelayBatchFlushIntervalMs {
+        || elapsedMs >= Self.proxyDelayBatchFlushIntervalMs
+      {
         flushPending()
       }
     }
@@ -5809,16 +5854,17 @@ final class AppModel {
       progress.finish()
     }
 
-      if cancelledItems.isEmpty,
-         let progress = proxyDelayBatchProgress,
-         progress.failureCount > 0 {
-        let message = String.localizedStringWithFormat(
-          NSLocalizedString("Batch delay test finished with %lld failures.", comment: ""),
-          Int64(progress.failureCount)
-        )
-        publishWarningNotice(message, logMessage: "\(message)\n\(progress.diagnosticText)")
-      }
-      reloadRuntimeData()
+    if cancelledItems.isEmpty,
+       let progress = proxyDelayBatchProgress,
+       progress.failureCount > 0
+    {
+      let message = String.localizedStringWithFormat(
+        NSLocalizedString("Batch delay test finished with %lld failures.", comment: ""),
+        Int64(progress.failureCount)
+      )
+      publishWarningNotice(message, logMessage: "\(message)\n\(progress.diagnosticText)")
+    }
+    reloadRuntimeData()
   }
 
   func healthCheckProvider(_ provider: ProxyProvider) {
@@ -5841,13 +5887,13 @@ final class AppModel {
       }
       do {
         try await apiClient.healthCheckProvider(named: provider.name)
-        guard self.providerHealthCheckTokens[provider.id] == token, !Task.isCancelled else { return }
-        self.reloadRuntimeData()
+        guard providerHealthCheckTokens[provider.id] == token, !Task.isCancelled else { return }
+        reloadRuntimeData()
       } catch is CancellationError {
         return
       } catch {
-        guard self.providerHealthCheckTokens[provider.id] == token, !Task.isCancelled else { return }
-        self.lastError = UserFacingError.message(for: error)
+        guard providerHealthCheckTokens[provider.id] == token, !Task.isCancelled else { return }
+        lastError = UserFacingError.message(for: error)
       }
     }
   }
@@ -5873,27 +5919,27 @@ final class AppModel {
       }
       do {
         try await apiClient.updateProxyProvider(named: provider.name)
-        guard self.proxyProviderUpdateTokens[provider.id] == token, !Task.isCancelled else { return }
-        self.providerAnalytics.recordUpdateAttempt(
+        guard proxyProviderUpdateTokens[provider.id] == token, !Task.isCancelled else { return }
+        providerAnalytics.recordUpdateAttempt(
           profileID: analyticsProfileID,
           kind: .proxy,
           providerName: provider.name,
           succeeded: true
         )
-        self.reloadRuntimeData()
+        reloadRuntimeData()
       } catch is CancellationError {
         return
       } catch {
-        guard self.proxyProviderUpdateTokens[provider.id] == token, !Task.isCancelled else { return }
+        guard proxyProviderUpdateTokens[provider.id] == token, !Task.isCancelled else { return }
         let message = UserFacingError.message(for: error)
-        self.providerAnalytics.recordUpdateAttempt(
+        providerAnalytics.recordUpdateAttempt(
           profileID: analyticsProfileID,
           kind: .proxy,
           providerName: provider.name,
           succeeded: false,
           errorMessage: message
         )
-        self.lastError = message
+        lastError = message
       }
     }
   }
@@ -5924,7 +5970,7 @@ final class AppModel {
       for provider in providers {
         do {
           try await apiClient.updateProxyProvider(named: provider.name)
-          self.providerAnalytics.recordUpdateAttempt(
+          providerAnalytics.recordUpdateAttempt(
             profileID: analyticsProfileID,
             kind: .proxy,
             providerName: provider.name,
@@ -5934,7 +5980,7 @@ final class AppModel {
           return
         } catch {
           let message = UserFacingError.message(for: error)
-          self.providerAnalytics.recordUpdateAttempt(
+          providerAnalytics.recordUpdateAttempt(
             profileID: analyticsProfileID,
             kind: .proxy,
             providerName: provider.name,
@@ -5944,11 +5990,11 @@ final class AppModel {
           failures.append((provider.name, message))
         }
       }
-      guard self.proxyProviderBatchUpdateToken == token, !Task.isCancelled else { return }
+      guard proxyProviderBatchUpdateToken == token, !Task.isCancelled else { return }
       if !failures.isEmpty {
-        self.lastError = Self.providerUpdateFailureSummary(kind: "proxy provider", failures: failures)
+        lastError = Self.providerUpdateFailureSummary(kind: "proxy provider", failures: failures)
       }
-      self.reloadRuntimeData()
+      reloadRuntimeData()
     }
   }
 
@@ -5973,27 +6019,27 @@ final class AppModel {
       }
       do {
         try await apiClient.updateRuleProvider(named: provider.name)
-        guard self.ruleProviderUpdateTokens[provider.id] == token, !Task.isCancelled else { return }
-        self.providerAnalytics.recordUpdateAttempt(
+        guard ruleProviderUpdateTokens[provider.id] == token, !Task.isCancelled else { return }
+        providerAnalytics.recordUpdateAttempt(
           profileID: analyticsProfileID,
           kind: .rule,
           providerName: provider.name,
           succeeded: true
         )
-        self.reloadRuntimeData()
+        reloadRuntimeData()
       } catch is CancellationError {
         return
       } catch {
-        guard self.ruleProviderUpdateTokens[provider.id] == token, !Task.isCancelled else { return }
+        guard ruleProviderUpdateTokens[provider.id] == token, !Task.isCancelled else { return }
         let message = UserFacingError.message(for: error)
-        self.providerAnalytics.recordUpdateAttempt(
+        providerAnalytics.recordUpdateAttempt(
           profileID: analyticsProfileID,
           kind: .rule,
           providerName: provider.name,
           succeeded: false,
           errorMessage: message
         )
-        self.lastError = message
+        lastError = message
       }
     }
   }
@@ -6024,7 +6070,7 @@ final class AppModel {
       for provider in providers {
         do {
           try await apiClient.updateRuleProvider(named: provider.name)
-          self.providerAnalytics.recordUpdateAttempt(
+          providerAnalytics.recordUpdateAttempt(
             profileID: analyticsProfileID,
             kind: .rule,
             providerName: provider.name,
@@ -6034,7 +6080,7 @@ final class AppModel {
           return
         } catch {
           let message = UserFacingError.message(for: error)
-          self.providerAnalytics.recordUpdateAttempt(
+          providerAnalytics.recordUpdateAttempt(
             profileID: analyticsProfileID,
             kind: .rule,
             providerName: provider.name,
@@ -6044,11 +6090,11 @@ final class AppModel {
           failures.append((provider.name, message))
         }
       }
-      guard self.ruleProviderBatchUpdateToken == token, !Task.isCancelled else { return }
+      guard ruleProviderBatchUpdateToken == token, !Task.isCancelled else { return }
       if !failures.isEmpty {
-        self.lastError = Self.providerUpdateFailureSummary(kind: "rule provider", failures: failures)
+        lastError = Self.providerUpdateFailureSummary(kind: "rule provider", failures: failures)
       }
-      self.reloadRuntimeData()
+      reloadRuntimeData()
     }
   }
 
@@ -6206,13 +6252,13 @@ final class AppModel {
       }
       do {
         try await apiClient.closeConnection(id: connection.id)
-        guard self.connectionCloseTokens[connection.id] == token, !Task.isCancelled else { return }
-        self.removeConnection(id: connection.id)
+        guard connectionCloseTokens[connection.id] == token, !Task.isCancelled else { return }
+        removeConnection(id: connection.id)
       } catch is CancellationError {
         return
       } catch {
-        guard self.connectionCloseTokens[connection.id] == token, !Task.isCancelled else { return }
-        self.lastError = UserFacingError.message(for: error)
+        guard connectionCloseTokens[connection.id] == token, !Task.isCancelled else { return }
+        lastError = UserFacingError.message(for: error)
       }
     }
   }
@@ -6240,13 +6286,13 @@ final class AppModel {
       }
       do {
         try await apiClient.closeAllConnections()
-        guard self.closeAllConnectionsToken == token, !Task.isCancelled else { return }
-        self.runtimeData.replaceConnections([])
+        guard closeAllConnectionsToken == token, !Task.isCancelled else { return }
+        runtimeData.replaceConnections([])
       } catch is CancellationError {
         return
       } catch {
-        guard self.closeAllConnectionsToken == token else { return }
-        self.lastError = UserFacingError.message(for: error)
+        guard closeAllConnectionsToken == token else { return }
+        lastError = UserFacingError.message(for: error)
       }
     }
   }
@@ -6336,37 +6382,37 @@ final class AppModel {
           self.tunSettingsApplyToken = nil
         }
       }
-      while self.tunSettingsApplyToken == token, !Task.isCancelled {
-        guard let settings = self.pendingTunSettingsApply else { return }
-        self.pendingTunSettingsApply = nil
+      while tunSettingsApplyToken == token, !Task.isCancelled {
+        guard let settings = pendingTunSettingsApply else { return }
+        pendingTunSettingsApply = nil
         do {
           try await applyRunningTunSettings(settings, reason: "TUN settings updated")
         } catch is CancellationError {
           return
         } catch {
-          guard self.tunSettingsApplyToken == token else { return }
+          guard tunSettingsApplyToken == token else { return }
           let message = UserFacingError.message(for: error)
-          if self.tunHelperStopUnconfirmed {
-            self.tunSettingsApplyTask = nil
-            self.tunSettingsApplyToken = nil
-            self.pendingTunSettingsApply = nil
-            let stopResult = await self.stopRuntimeCoordinated(.safetyShutdown)
-            self.handleStopResult(stopResult)
-            self.lastError = stopResult.succeeded
+          if tunHelperStopUnconfirmed {
+            tunSettingsApplyTask = nil
+            tunSettingsApplyToken = nil
+            pendingTunSettingsApply = nil
+            let stopResult = await stopRuntimeCoordinated(.safetyShutdown)
+            handleStopResult(stopResult)
+            lastError = stopResult.succeeded
               ? "TUN settings could not be applied after helper restart, so ClashMax stopped TUN safely: \(message)"
               : "TUN settings could not be applied and TUN cleanup also failed: \(message)"
             return
           }
           // If a newer save arrived while this operation was in flight, apply
           // that latest value before surfacing an obsolete failure.
-          if self.pendingTunSettingsApply == nil {
+          if pendingTunSettingsApply == nil {
             lastError = "Could not apply TUN settings without restart: \(message)"
             return
           }
           continue
         }
-        guard self.tunSettingsApplyToken == token, !Task.isCancelled else { return }
-        if self.pendingTunSettingsApply == nil {
+        guard tunSettingsApplyToken == token, !Task.isCancelled else { return }
+        if pendingTunSettingsApply == nil {
           recordAppliedRuntimeSettingsSnapshot(makeRuntimeSettingsSnapshot(owner: .tunnel))
           lastError = nil
         }
@@ -6381,7 +6427,7 @@ final class AppModel {
   ) async throws {
     try await tunRuntimeMutationGate.run { @Sendable [weak self] in
       guard let self else { return }
-      try await self.performRunningTunSettings(
+      try await performRunningTunSettings(
         settings,
         runtimeOverrides: runtimeOverrides,
         reason: reason
@@ -6460,8 +6506,8 @@ final class AppModel {
     }
     let clientForRuntime: any MihomoAPIControlling
     if controllerIdentityChanged || apiClient == nil {
-      clientForRuntime = MihomoAPIClient(
-        baseURL: try effectiveOverrides.endpoint.baseURL,
+      clientForRuntime = try MihomoAPIClient(
+        baseURL: effectiveOverrides.endpoint.baseURL,
         secret: effectiveOverrides.secret
       )
     } else if let apiClient {
@@ -6500,7 +6546,7 @@ final class AppModel {
     try Task.checkCancellation()
     do {
       let response = try await helperClient.restartTunnel(
-        coreURL: try bundledCoreURL(),
+        coreURL: bundledCoreURL(),
         configURL: runtimeConfig,
         workDirectory: paths.runtime,
         secret: runtimeOverrides.secret
@@ -6541,7 +6587,7 @@ final class AppModel {
   ) async throws -> Bool {
     var didRestartHelper = didRestartHelper
     let postReloadSnapshot = await routingSnapshotConfirmedByDataPlane(
-      await inspectTunRuntimeNow(
+      inspectTunRuntimeNow(
         includeExternal: false,
         runtimeOverrides: runtimeOverrides
       ),
@@ -6564,7 +6610,7 @@ final class AppModel {
       )
       didRestartHelper = true
       let postRestartSnapshot = await routingSnapshotConfirmedByDataPlane(
-        await inspectTunRuntimeNow(
+        inspectTunRuntimeNow(
           includeExternal: false,
           runtimeOverrides: runtimeOverrides
         ),
@@ -6738,7 +6784,7 @@ final class AppModel {
       do {
         try await tunRuntimeMutationGate.run { @Sendable [weak self] in
           guard let self else { return }
-          try await self.performTunDNSRepair()
+          try await performTunDNSRepair()
         }
       } catch is CancellationError {
         return
@@ -6783,7 +6829,7 @@ final class AppModel {
       do {
         try await tunRuntimeMutationGate.run { @Sendable [weak self] in
           guard let self else { return }
-          try await self.performTunRoutingRepair()
+          try await performTunRoutingRepair()
         }
       } catch is CancellationError {
         return
@@ -6852,7 +6898,7 @@ final class AppModel {
       }
 
       let postReloadSnapshot = await routingSnapshotConfirmedByDataPlane(
-        await inspectTunRuntimeNow(
+        inspectTunRuntimeNow(
           includeExternal: false,
           runtimeOverrides: runtimeOverrides
         ),
@@ -6868,7 +6914,7 @@ final class AppModel {
         activateRuntimeArtifacts(materialization)
         didRestartHelper = true
         let postRestartSnapshot = await routingSnapshotConfirmedByDataPlane(
-          await inspectTunRuntimeNow(
+          inspectTunRuntimeNow(
             includeExternal: false,
             runtimeOverrides: runtimeOverrides
           ),
@@ -6915,7 +6961,7 @@ final class AppModel {
         helperPID: helperStatus.pid,
         helperStatusMessage: helperStatus.message,
         systemDNSState: tunSystemDNSState,
-        systemProxyState: await sampleLocalSystemProxyState(servedPorts: servedPorts),
+        systemProxyState: sampleLocalSystemProxyState(servedPorts: servedPorts),
         servedLocalProxyPorts: servedPorts,
         includeExternal: includeExternal
       )
@@ -7122,11 +7168,11 @@ final class AppModel {
     networkExtensionDiagnosticsTask = Task { @MainActor [weak self] in
       while !Task.isCancelled {
         guard let self else { return }
-        guard self.runtimeOwner == .networkExtension || self.networkExtensionController.vpnStatus.isActive else {
+        guard runtimeOwner == .networkExtension || networkExtensionController.vpnStatus.isActive else {
           return
         }
-        self.networkExtensionController.refreshDiagnostics()
-        self.publishNetworkExtensionDiagnostics()
+        networkExtensionController.refreshDiagnostics()
+        publishNetworkExtensionDiagnostics()
         do {
           try await Task.sleep(nanoseconds: 1_000_000_000)
         } catch {
@@ -7159,11 +7205,11 @@ final class AppModel {
     let context = [
       event.flowProtocol?.displayName,
       event.remoteEndpoint,
-      event.sourceAppSigningIdentifier.map { "source=\($0)" }
+      event.sourceAppSigningIdentifier.map { "source=\($0)" },
     ]
-      .compactMap { $0 }
-      .filter { !$0.isEmpty }
-      .joined(separator: " ")
+    .compactMap(\.self)
+    .filter { !$0.isEmpty }
+    .joined(separator: " ")
     if !context.isEmpty {
       return "\(prefix): \(event.message) \(context)"
     }
@@ -7252,11 +7298,11 @@ final class AppModel {
     previewTask = Task { [weak self] in
       try? await Task.sleep(nanoseconds: 50_000_000)
       guard let self, !Task.isCancelled else { return }
-      guard self.canStartPreviewRuntime() else {
-        self.previewTask = nil
+      guard canStartPreviewRuntime() else {
+        previewTask = nil
         return
       }
-      await self.startPreviewRuntime()
+      await startPreviewRuntime()
     }
   }
 
@@ -7265,30 +7311,30 @@ final class AppModel {
     cancelPendingPreviewRuntimeStart()
     previewTask = Task { @MainActor [weak self] in
       guard let self else { return }
-      if self.previewRuntimeActive {
-        let result = await self.leavePreviewRuntimeResult(cancelsPendingStart: false)
+      if previewRuntimeActive {
+        let result = await leavePreviewRuntimeResult(cancelsPendingStart: false)
         guard result.succeeded else {
-          self.previewTask = nil
+          previewTask = nil
           if let message = result.userFacingMessage {
-            self.appendAppLog(level: "debug", message: "Preview runtime restart skipped after \(reason): \(message)")
+            appendAppLog(level: "debug", message: "Preview runtime restart skipped after \(reason): \(message)")
           }
           return
         }
       }
       guard !Task.isCancelled else {
-        self.previewTask = nil
+        previewTask = nil
         return
       }
       try? await Task.sleep(nanoseconds: 50_000_000)
       guard !Task.isCancelled else {
-        self.previewTask = nil
+        previewTask = nil
         return
       }
-      guard self.canStartPreviewRuntime() else {
-        self.previewTask = nil
+      guard canStartPreviewRuntime() else {
+        previewTask = nil
         return
       }
-      await self.startPreviewRuntime()
+      await startPreviewRuntime()
     }
   }
 
@@ -7359,13 +7405,13 @@ final class AppModel {
         overrides: previewOverrides
       )
       let runtimeConfig = materialization.runtimeConfigURL
-      let client = MihomoAPIClient(baseURL: try previewOverrides.endpoint.baseURL, secret: previewOverrides.secret)
+      let client = try MihomoAPIClient(baseURL: previewOverrides.endpoint.baseURL, secret: previewOverrides.secret)
       previewRuntimeOverrides = previewOverrides
       previewRuntimeActive = true
       runtimeOwner = .preview
       try Task.checkCancellation()
       try await coreController.startUserMode(
-        coreURL: try bundledCoreURL(),
+        coreURL: bundledCoreURL(),
         configURL: runtimeConfig,
         workDirectory: paths.runtime,
         api: previewOverrides.endpoint,
@@ -7379,7 +7425,7 @@ final class AppModel {
         let knownDelayStates = proxyDelayStateMap(from: proxyGroups)
         let cachedRuntimeGroups = proxyGroups
         let runtimeGroups = try await client.proxyGroups()
-        let providers = (try? await client.structuredProxyProviders()) ?? []
+        let providers = await (try? client.structuredProxyProviders()) ?? []
         proxyProviders = providersPreservingKnownDelayStates(providers)
         proxyGroups = enrichProxyGroupsWithKnownEndpoints(
           runtimeGroups,
@@ -7416,7 +7462,8 @@ final class AppModel {
       let inFlightPurpose = stopTaskPurpose
       let result = await activeStopTask.value
       if purpose != .settingsApplyRestart,
-         inFlightPurpose == .settingsApplyRestart {
+         inFlightPurpose == .settingsApplyRestart
+      {
         stopTask = nil
         stopTaskID = nil
         stopTaskPurpose = nil
@@ -7426,7 +7473,8 @@ final class AppModel {
             inFlightPurpose != .termination,
             result.networkExtensionStopError != nil,
             !result.didRunLocalCleanup,
-            needsTerminationCleanup else {
+            needsTerminationCleanup
+      else {
         return result
       }
       stopTask = nil
@@ -7441,7 +7489,7 @@ final class AppModel {
     let taskID = UUID()
     let task = Task { @MainActor [weak self] in
       guard let self else { return RuntimeStopResult.success }
-      return await self.stopRuntime(purpose: purpose)
+      return await stopRuntime(purpose: purpose)
     }
     stopTask = task
     stopTaskID = taskID
@@ -7459,7 +7507,8 @@ final class AppModel {
     guard !result.succeeded, let message = result.userFacingMessage else { return }
     if result.systemProxyRestoreError == nil,
        result.helperStopError == nil,
-       result.networkExtensionStopError != nil {
+       result.networkExtensionStopError != nil
+    {
       setNetworkExtensionLastError(message)
     } else {
       lastError = message
@@ -7608,7 +7657,8 @@ final class AppModel {
     if result.networkExtensionStopError == nil,
        result.networkExtensionDNSRestoreError == nil,
        result.tunDNSRestoreError == nil,
-       systemProxyController.hasManagedSystemDNSState {
+       systemProxyController.hasManagedSystemDNSState
+    {
       do {
         let dnsResult = try await systemProxyController.restoreDNS()
         let restoredState: SystemDNSOverrideState = dnsResult.restoredSnapshotCount > 0 ? .restored : .inactive
@@ -7700,13 +7750,13 @@ final class AppModel {
     await profileCoordinator.waitForPreviewRefresh()
   }
 
-    private func runtimeAPIClientForProxyAction() -> (any MihomoAPIControlling)? {
-      guard canControlRuntimeProxies, let apiClient else {
-        publishWarningNotice(proxyRuntimeActionMessage)
-        return nil
-      }
-      return apiClient
+  private func runtimeAPIClientForProxyAction() -> (any MihomoAPIControlling)? {
+    guard canControlRuntimeProxies, let apiClient else {
+      publishWarningNotice(proxyRuntimeActionMessage)
+      return nil
     }
+    return apiClient
+  }
 
   private func applySelectedProxy(groupName: String, nodeName: String?) {
     updateProxyGroupCollections { groups in
@@ -7837,7 +7887,8 @@ final class AppModel {
         let node = groups[groupIndex].nodes[nodeIndex]
         let resolved: ProxyDelayState?
         if let providerName = node.providerName,
-           let match = exactByProvider[Self.nodeMatchKey(group: groupName, node: node.name, provider: providerName)] {
+           let match = exactByProvider[Self.nodeMatchKey(group: groupName, node: node.name, provider: providerName)]
+        {
           resolved = match
         } else {
           resolved = wildcardByName[Self.nodeMatchKey(group: groupName, node: node.name)]
@@ -7947,7 +7998,8 @@ final class AppModel {
       return .cancelled
     }
     if let clientError = error as? MihomoAPIClient.ClientError,
-       case .delayTestHTTPStatus = clientError {
+       case .delayTestHTTPStatus = clientError
+    {
       return .other
     }
     if let delayError = error as? DelayTestError {
@@ -7964,7 +8016,8 @@ final class AppModel {
       return .timeout
     }
     if normalized.contains("controller responded")
-      || normalized.contains("delay probe returned http") {
+      || normalized.contains("delay probe returned http")
+    {
       return .other
     }
     if normalized.contains("mihomo controller")
@@ -7973,7 +8026,8 @@ final class AppModel {
       || normalized.contains("cannot connect to the server")
       || normalized.contains("unable to connect to the server")
       || normalized.contains("无法连接服务器")
-      || normalized.contains("127.0.0.1:9097") {
+      || normalized.contains("127.0.0.1:9097")
+    {
       return .controllerUnavailable
     }
     return .other
@@ -8103,13 +8157,14 @@ final class AppModel {
     if let providerName = node.providerName,
        let provider = proxyProviders.first(where: { $0.name == providerName }),
        let providerNode = provider.proxies.first(where: { $0.name == node.name }),
-       let endpoint = proxyEndpoint(from: providerNode) {
+       let endpoint = proxyEndpoint(from: providerNode)
+    {
       return endpoint.host
     }
     let endpointMaps = [
       proxyEndpointMap(from: proxyProviders),
       proxyEndpointMap(from: profilePreviewGroups),
-      proxyEndpointMap(from: proxyGroups)
+      proxyEndpointMap(from: proxyGroups),
     ]
     return endpointMaps.lazy.compactMap { $0[node.name]?.host }.first
   }
@@ -8123,7 +8178,7 @@ final class AppModel {
     let endpointMaps = [
       proxyEndpointMap(from: providers),
       proxyEndpointMap(from: profilePreviewGroups),
-      proxyEndpointMap(from: cachedRuntimeGroups)
+      proxyEndpointMap(from: cachedRuntimeGroups),
     ]
     return groups.map { group in
       var group = group
@@ -8276,7 +8331,7 @@ final class AppModel {
       }
     case .requireCore:
       optionalCoreErrorMessage = nil
-      preflightMode = .validate(coreURL: try bundledCoreURL(), validator: MihomoRuntimeConfigValidator())
+      preflightMode = try .validate(coreURL: bundledCoreURL(), validator: MihomoRuntimeConfigValidator())
     }
     let effectiveRuntimeOptions: RuntimeConfigOptions
     if let runtimeOptions {
@@ -8415,7 +8470,7 @@ final class AppModel {
     let architecture = ProcessInfo.processInfo.machineHardwareName.contains("x86") ? "amd64" : "arm64"
     let candidates = [
       AppConstants.bundledCoreRoot.appendingPathComponent("mihomo"),
-      AppConstants.bundledCoreRoot.appendingPathComponent("mihomo-darwin-\(architecture)")
+      AppConstants.bundledCoreRoot.appendingPathComponent("mihomo-darwin-\(architecture)"),
     ]
     guard let core = candidates.first(where: { FileManager.default.isExecutableFile(atPath: $0.path) }) else {
       throw AppError.missingBundledCore
@@ -8437,7 +8492,7 @@ final class AppModel {
       },
       Task { [weak self] in
         await self?.runConnectionStream(client: client, token: token)
-      }
+      },
     ]
     reloadRuntimeData()
   }
@@ -8562,7 +8617,7 @@ final class AppModel {
     if Self.informationalStartupDiagnosticPrefixes.contains(where: { normalized.hasPrefix($0) }) {
       return "info"
     }
-    if normalized.hasPrefix("mihomo pid ") && normalized.contains("did not exit after sigterm") {
+    if normalized.hasPrefix("mihomo pid "), normalized.contains("did not exit after sigterm") {
       return "warn"
     }
     if Self.failureStartupDiagnosticPrefixes.contains(where: { normalized.hasPrefix($0) }) {
@@ -8578,14 +8633,14 @@ final class AppModel {
     "checking runtime ports:",
     "launching mihomo with config:",
     "mihomo launch pid:",
-    "mihomo controller ready:"
+    "mihomo controller ready:",
   ]
 
   private static let failureStartupDiagnosticPrefixes = [
     "port ",
     "readiness failed:",
     "mihomo exited before controller readiness:",
-    "core tail:"
+    "core tail:",
   ]
 
   private func startupDiagnosticsSummary() -> String {
@@ -8628,7 +8683,6 @@ final class AppModel {
       }
     )
   }
-
 }
 
 private enum DelayTestError: LocalizedError {
@@ -8730,7 +8784,7 @@ extension UTType {
   }
 }
 
-private extension Array where Element == ProxyGroup {
+private extension [ProxyGroup] {
   func preservingKnownDelayStates(_ knownStates: [ProxyNodeKey: ProxyDelayState], profileID: Profile.ID?) -> [ProxyGroup] {
     map { group in
       var group = group

--- a/ClashMax/Stores/PersistedSettingsStore.swift
+++ b/ClashMax/Stores/PersistedSettingsStore.swift
@@ -9,88 +9,104 @@ final class PersistedSettingsStore {
       saveRuntimeSettings(overrides)
     }
   }
+
   var proxyRoutingMode: ProxyRoutingMode = .systemProxy {
     didSet {
       saveCodable(proxyRoutingMode, forKey: Self.proxyRoutingModeDefaultsKey)
     }
   }
+
   var systemProxySettings = SystemProxySettings.default {
     didSet {
       saveCodable(systemProxySettings, forKey: Self.systemProxySettingsDefaultsKey)
     }
   }
+
   var ipv6Enabled = false {
     didSet {
       overrides.ipv6Enabled = ipv6Enabled
       defaults.set(ipv6Enabled, forKey: Self.ipv6EnabledDefaultsKey)
     }
   }
+
   var tunSettings = TunSettings.default {
     didSet {
       overrides.tunSettings = tunSettings
       saveCodable(tunSettings, forKey: Self.tunSettingsDefaultsKey)
     }
   }
+
   var networkExtensionRoutingSettings = NetworkExtensionRoutingSettings.default {
     didSet {
       saveCodable(networkExtensionRoutingSettings, forKey: Self.networkExtensionRoutingSettingsDefaultsKey)
     }
   }
+
   var ruleOverlaySettings = RuleOverlaySettings.disabled {
     didSet {
       overrides.ruleOverlay = ruleOverlaySettings
       saveCodable(ruleOverlaySettings, forKey: Self.ruleOverlaySettingsDefaultsKey)
     }
   }
+
   var delayTestSettings = DelayTestSettings.default {
     didSet {
       overrides.unifiedDelay = delayTestSettings.unifiedDelay
       saveCodable(delayTestSettings, forKey: Self.delayTestSettingsDefaultsKey)
     }
   }
+
   var subscriptionFetchSettings = SubscriptionFetchSettings.default {
     didSet {
       saveCodable(subscriptionFetchSettings, forKey: Self.subscriptionFetchSettingsDefaultsKey)
       onSubscriptionFetchSettingsChange?()
     }
   }
+
   var menuBarPinnedGroupSettings = MenuBarPinnedGroupSettings.default {
     didSet {
       saveCodable(menuBarPinnedGroupSettings, forKey: Self.menuBarPinnedGroupSettingsDefaultsKey)
     }
   }
+
   var proxyPageSettings = ProxyPageSettings.default {
     didSet {
       saveCodable(proxyPageSettings, forKey: Self.proxyPageSettingsDefaultsKey)
     }
   }
+
   var globalShortcutSettings = GlobalShortcutSettings.default {
     didSet {
       saveCodable(globalShortcutSettings, forKey: Self.globalShortcutSettingsDefaultsKey)
       onGlobalShortcutSettingsChange?(globalShortcutSettings)
     }
   }
+
   var externalDashboardProfiles: [ExternalDashboardProfile] = [] {
     didSet {
       saveCodable(externalDashboardProfiles, forKey: Self.externalDashboardProfilesDefaultsKey)
     }
   }
+
   var networkPolicySettings = NetworkPolicySettings.default {
     didSet {
       saveCodable(networkPolicySettings, forKey: Self.networkPolicySettingsDefaultsKey)
     }
   }
+
   var appTheme = AppTheme.system {
     didSet {
       saveCodable(appTheme, forKey: Self.appThemeDefaultsKey)
     }
   }
+
   var externalControllerSettings = ExternalControllerSettings.default {
     didSet {
       syncExternalControllerSettings()
       saveExternalControllerSettings(externalControllerSettings)
     }
   }
+
   private(set) var appliedRuntimeSettingsSnapshot: AppliedRuntimeSettingsSnapshot?
   private(set) var launchSettings = LaunchSettings.default
   private(set) var initialTunHelperPromptHandled: Bool
@@ -212,7 +228,7 @@ final class PersistedSettingsStore {
       defaults: defaults
     ) ?? [
       ExternalDashboardProfile(name: "YACD", url: URL(string: "https://yacd.metacubex.one")!, readOnly: true),
-      ExternalDashboardProfile(name: "MetaCubeX", url: URL(string: "https://metacubex.github.io/metacubexd")!, readOnly: true)
+      ExternalDashboardProfile(name: "MetaCubeX", url: URL(string: "https://metacubex.github.io/metacubexd")!, readOnly: true),
     ]
     networkPolicySettings = Self.loadCodable(
       NetworkPolicySettings.self,

--- a/ClashMax/Stores/ProfileOperationsStore.swift
+++ b/ClashMax/Stores/ProfileOperationsStore.swift
@@ -25,7 +25,7 @@ final class ProfileCoordinator {
   ) {
     self.profileStore = profileStore
     self.proxyPreview = proxyPreview
-    self.subscriptionScheduler = SubscriptionAutoUpdateScheduler(retryDelay: subscriptionAutoUpdateRetryDelay)
+    subscriptionScheduler = SubscriptionAutoUpdateScheduler(retryDelay: subscriptionAutoUpdateRetryDelay)
   }
 
   func configureRuntimeHooks(
@@ -483,7 +483,7 @@ final class ProfileCoordinator {
         let updated = try await updateSubscriptionWithoutPostActions(
           profile,
           session: .shared,
-          fetchOptions: try await hooks.subscriptionFetchOptions(profile),
+          fetchOptions: hooks.subscriptionFetchOptions(profile),
           preflightValidator: hooks.preflightValidator(),
           trigger: cancelScheduledTask ? .manual : .automatic
         )
@@ -526,9 +526,11 @@ private struct ProfileCoordinatorHooks {
   var subscriptionFetchOptions: (Profile?) async throws -> SubscriptionFetchOptions = {
     _ in SubscriptionFetchOptions()
   }
+
   var preflightValidator: () -> any SubscriptionProfilePreflightValidating = {
     NoopSubscriptionProfilePreflightValidator()
   }
+
   var reloadActiveRuntimeConfigIfNeeded: (Profile.ID, String) async throws -> Void = { _, _ in }
   var appendAppLog: (String, String) -> Void = { _, _ in }
   var notifySubscriptionUpdateFailure: (String, String) -> Void = { _, _ in }
@@ -544,7 +546,7 @@ private final class SubscriptionAutoUpdateScheduler {
   private var task: Task<Void, Never>?
 
   init(retryDelay: TimeInterval) {
-    self.initialRetryDelay = retryDelay
+    initialRetryDelay = retryDelay
   }
 
   func cancel() {
@@ -612,7 +614,8 @@ private final class SubscriptionAutoUpdateScheduler {
       .addingTimeInterval(TimeInterval(intervalMinutes * 60))
     if let backoffDate = profile.subscriptionUpdateStatus.backoffUntil,
        backoffDate > now,
-       baseDate <= now {
+       baseDate <= now
+    {
       return backoffDate
     }
     return baseDate

--- a/ClashMax/Stores/ProfileStore.swift
+++ b/ClashMax/Stores/ProfileStore.swift
@@ -123,8 +123,8 @@ struct SubscriptionPreflightValidationError: Error, LocalizedError, CustomString
     // Prefer the extracted short summary (the actual Mihomo failure line) over the
     // raw error text, which UserFacingError truncates to its first ~217 chars and
     // would surface only the benign log head (see issue #7).
-    self.message = diagnostics.localizedMessage ?? UserFacingError.message(for: error)
-    self.fullMessage = diagnostics.fullMessage
+    message = diagnostics.localizedMessage ?? UserFacingError.message(for: error)
+    fullMessage = diagnostics.fullMessage
     self.diagnostics = diagnostics
   }
 
@@ -219,7 +219,7 @@ struct MihomoSubscriptionProfilePreflightValidator: SubscriptionProfilePreflight
     // `preflightDirectory`, so the temporary artifacts (referenced by absolute
     // path) stay inside SAFE_PATHS while the geodata cache persists for reuse.
     try await runtimeConfigValidator.validate(
-      coreURL: try coreURLProvider(),
+      coreURL: coreURLProvider(),
       configURL: runtimeConfigURL,
       workDirectory: paths.runtime
     )
@@ -242,6 +242,7 @@ final class ProfileStore {
       onProfilesChange?(profiles)
     }
   }
+
   private(set) var activeProfileID: Profile.ID?
   private(set) var subscriptionURLCache: [Profile.ID: String] = [:]
 
@@ -259,7 +260,7 @@ final class ProfileStore {
   ) {
     self.paths = paths
     self.diskIO = diskIO
-    self.secretIO = ProfileSecretIO(store: keychain)
+    secretIO = ProfileSecretIO(store: keychain)
     manifestLoadTask = Task { @MainActor [weak self] in
       await self?.loadManifestFromDisk()
     }
@@ -326,7 +327,8 @@ final class ProfileStore {
       guard let index = profiles.firstIndex(where: { $0.id == profile.id }) else { return }
       let current = profiles[index]
       if case let .manualProxy(manualEndpointID) = current.source,
-         endpointID == manualEndpointID {
+         endpointID == manualEndpointID
+      {
         throw ProfileStoreError.manualProfileCannotUseOwnEndpoint(manualEndpointID)
       }
       guard current.upstreamEndpointID != endpointID else { return }
@@ -345,7 +347,8 @@ final class ProfileStore {
       profiles.flatMap { profile in
         var references: [OutboundProxyEndpointReference] = []
         if case let .manualProxy(manualEndpointID) = profile.source,
-           manualEndpointID == endpointID {
+           manualEndpointID == endpointID
+        {
           references.append(
             OutboundProxyEndpointReference(
               profileID: profile.id,
@@ -411,12 +414,13 @@ final class ProfileStore {
     await waitForManifestLoad()
     return try await withMutationLock {
       if let upstreamEndpointID,
-         fetchOptions.profileUpstreamEndpoint?.endpoint.id != upstreamEndpointID {
+         fetchOptions.profileUpstreamEndpoint?.endpoint.id != upstreamEndpointID
+      {
         throw ProfileStoreError.unresolvedUpstreamEndpoint(upstreamEndpointID)
       }
       let resolution = try Self.resolvedSubscriptionURL(from: url, displayNameHint: displayNameHint)
-      let result = Self.fetchResult(
-        try await fetchSubscription(url: resolution.url, session: session, options: fetchOptions),
+      let result = try await Self.fetchResult(
+        fetchSubscription(url: resolution.url, session: session, options: fetchOptions),
         displayNameHint: resolution.displayNameHint
       )
       let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -513,8 +517,8 @@ final class ProfileStore {
       let previousSource = try? await diskIO.readProfileSource(atPath: profile.originalConfigPath)
       let result: SubscriptionFetchResult
       do {
-        result = Self.fetchResult(
-          try await fetchSubscription(url: resolution.url, session: session, options: fetchOptions),
+        result = try await Self.fetchResult(
+          fetchSubscription(url: resolution.url, session: session, options: fetchOptions),
           displayNameHint: resolution.displayNameHint
         )
       } catch {
@@ -584,8 +588,8 @@ final class ProfileStore {
       let previousURL = try await storedSubscriptionURL(for: id)
       let result: SubscriptionFetchResult
       do {
-        result = Self.fetchResult(
-          try await fetchSubscription(url: resolution.url, session: session, options: fetchOptions),
+        result = try await Self.fetchResult(
+          fetchSubscription(url: resolution.url, session: session, options: fetchOptions),
           displayNameHint: resolution.displayNameHint
         )
       } catch {
@@ -683,8 +687,8 @@ final class ProfileStore {
       let previousURL = try await storedSubscriptionURL(for: id)
       let result: SubscriptionFetchResult
       do {
-        result = Self.fetchResult(
-          try await fetchSubscription(url: resolution.url, session: session, options: fetchOptions),
+        result = try await Self.fetchResult(
+          fetchSubscription(url: resolution.url, session: session, options: fetchOptions),
           displayNameHint: resolution.displayNameHint
         )
       } catch {
@@ -789,7 +793,7 @@ final class ProfileStore {
             let url = URL(string: rawURL),
             let resolution = SubscriptionURLResolver.resolve(url: url)
       else { return }
-      let source = (try? await diskIO.readProfileSource(atPath: profile.originalConfigPath)) ?? ""
+      let source = await (try? diskIO.readProfileSource(atPath: profile.originalConfigPath)) ?? ""
       let metadata = profiles[index].subscriptionMetadata ?? SubscriptionMetadata()
       let displayName = await Self.subscriptionDisplayNameAsync(metadata: metadata, source: source, url: resolution.url)
       var nextProfiles = profiles
@@ -1234,15 +1238,15 @@ final class ProfileStore {
     }
   }
 
-  nonisolated private static func subscriptionAccount(for id: UUID) -> String {
+  private nonisolated static func subscriptionAccount(for id: UUID) -> String {
     "subscription.\(id.uuidString)"
   }
 
-  nonisolated private static func subscriptionHeaderAccount(subscriptionID: UUID, headerID: UUID) -> String {
+  private nonisolated static func subscriptionHeaderAccount(subscriptionID: UUID, headerID: UUID) -> String {
     "subscription.\(subscriptionID.uuidString).header.\(headerID.uuidString)"
   }
 
-  nonisolated private static func subscriptionRuntimeMergeAccount(subscriptionID: UUID) -> String {
+  private nonisolated static func subscriptionRuntimeMergeAccount(subscriptionID: UUID) -> String {
     "subscription.\(subscriptionID.uuidString).runtimeMergeYAML"
   }
 
@@ -1486,7 +1490,7 @@ final class ProfileStore {
     }
   }
 
-  nonisolated private static func fullPreflightDiagnostic(from error: Error) -> String? {
+  private nonisolated static func fullPreflightDiagnostic(from error: Error) -> String? {
     if case let AppError.configValidationFailed(payload) = error {
       return SubscriptionPreflightDiagnosticFormatter.fullDiagnostic(fromFullMessage: payload)
     }
@@ -1511,7 +1515,7 @@ final class ProfileStore {
     return nil
   }
 
-  nonisolated private static func requiresSubscriptionPreflight(
+  private nonisolated static func requiresSubscriptionPreflight(
     subscriptionSource: String,
     providerOptions: SubscriptionProviderOptions
   ) -> Bool {
@@ -1521,7 +1525,7 @@ final class ProfileStore {
     return (try? ProfileConfigInspector.format(of: subscriptionSource)) != nil
   }
 
-  nonisolated private static func subscriptionHistoryEntry(
+  private nonisolated static func subscriptionHistoryEntry(
     profile: Profile,
     trigger: SubscriptionUpdateTrigger,
     result: SubscriptionUpdateResult,
@@ -1545,7 +1549,7 @@ final class ProfileStore {
     (error as? SubscriptionFetchError)?.diagnostics
   }
 
-  nonisolated private static func resolvedSubscriptionURL(
+  private nonisolated static func resolvedSubscriptionURL(
     from url: URL,
     displayNameHint: String? = nil
   ) throws -> SubscriptionURLResolution {
@@ -1558,7 +1562,7 @@ final class ProfileStore {
     return resolution
   }
 
-  nonisolated private static func fetchResult(
+  private nonisolated static func fetchResult(
     _ result: SubscriptionFetchResult,
     displayNameHint: String?
   ) -> SubscriptionFetchResult {
@@ -1696,9 +1700,9 @@ final class ProfileStore {
     replacing currentProfile: Profile,
     with nextProfile: Profile
   ) async -> ProviderOptionSecretSnapshot {
-    ProviderOptionSecretSnapshot(
-      headers: await headerSecretSnapshot(replacing: currentProfile, with: nextProfile),
-      runtimeMergeYAML: await runtimeMergeSecretSnapshot(for: currentProfile)
+    await ProviderOptionSecretSnapshot(
+      headers: headerSecretSnapshot(replacing: currentProfile, with: nextProfile),
+      runtimeMergeYAML: runtimeMergeSecretSnapshot(for: currentProfile)
     )
   }
 
@@ -1877,7 +1881,7 @@ final class ProfileStore {
     }
   }
 
-  nonisolated private static func subscriptionDisplayNameAsync(
+  private nonisolated static func subscriptionDisplayNameAsync(
     metadata: SubscriptionMetadata,
     source: String,
     url: URL
@@ -1887,8 +1891,8 @@ final class ProfileStore {
     }.value
   }
 
-  nonisolated private static func subscriptionDisplayName(metadata: SubscriptionMetadata, source: String, url: URL) -> String {
-    if let remoteName = metadata.remoteFileName.map(Self.normalizedRemoteProfileName), !remoteName.isEmpty {
+  private nonisolated static func subscriptionDisplayName(metadata: SubscriptionMetadata, source: String, url: URL) -> String {
+    if let remoteName = metadata.remoteFileName.map(normalizedRemoteProfileName), !remoteName.isEmpty {
       return remoteName
     }
     if let displayNameHint = metadata.displayNameHint, !displayNameHint.isEmpty {
@@ -1906,7 +1910,7 @@ final class ProfileStore {
     return "Subscription"
   }
 
-  nonisolated private static func normalizedRemoteProfileName(_ value: String) -> String {
+  private nonisolated static func normalizedRemoteProfileName(_ value: String) -> String {
     let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
     let url = URL(fileURLWithPath: trimmed)
     let withoutExtension = ["yaml", "yml", "txt"].contains(url.pathExtension.lowercased())
@@ -1915,7 +1919,7 @@ final class ProfileStore {
     return withoutExtension.trimmingCharacters(in: .whitespacesAndNewlines)
   }
 
-  nonisolated private static func profileName(fromURLPath url: URL) -> String? {
+  private nonisolated static func profileName(fromURLPath url: URL) -> String? {
     let segments = url.path(percentEncoded: false)
       .split(separator: "/")
       .map(String.init)
@@ -1924,7 +1928,7 @@ final class ProfileStore {
     return normalized.isEmpty ? nil : normalized
   }
 
-  nonisolated private static func profileName(from source: String) -> String? {
+  private nonisolated static func profileName(from source: String) -> String? {
     guard let root = try? Yams.load(yaml: source) as? [String: Any] else { return nil }
     if let groups = root["proxy-groups"] as? [[String: Any]] {
       for group in groups {
@@ -1934,7 +1938,8 @@ final class ProfileStore {
       }
     }
     if let providers = root["proxy-providers"] as? [String: Any],
-       let name = providers.keys.sorted().first {
+       let name = providers.keys.sorted().first
+    {
       let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
       if !trimmed.isEmpty { return trimmed }
     }

--- a/ClashMax/Stores/ProviderAnalyticsStore.swift
+++ b/ClashMax/Stores/ProviderAnalyticsStore.swift
@@ -19,7 +19,7 @@ final class ProviderAnalyticsStore {
   private let fileManager: FileManager
 
   init(paths: RuntimePaths, fileManager: FileManager = .default) {
-    self.fileURL = paths.providerAnalyticsURL
+    fileURL = paths.providerAnalyticsURL
     self.fileManager = fileManager
     load()
   }

--- a/ClashMax/Stores/ProxyPreviewStore.swift
+++ b/ClashMax/Stores/ProxyPreviewStore.swift
@@ -11,6 +11,7 @@ final class ProxyPreviewStore {
       onProfilePreviewGroupsChange?(profilePreviewGroups)
     }
   }
+
   var previewRuntimeActive = false
   var previewSelections: [String: String] = [:]
 
@@ -54,8 +55,8 @@ final class ProxyPreviewStore {
         groups = []
       }
       guard !Task.isCancelled else { return }
-      guard let self, self.refreshGeneration == generation else { return }
-      self.profilePreviewGroups = groups
+      guard let self, refreshGeneration == generation else { return }
+      profilePreviewGroups = groups
     }
     refreshTask = task
     return task
@@ -126,7 +127,8 @@ final class ProxyPreviewStore {
     return groups.map { group in
       var group = group
       if let chosen = previewSelections[group.name],
-         group.nodes.contains(where: { $0.name == chosen }) {
+         group.nodes.contains(where: { $0.name == chosen })
+      {
         group.selected = chosen
       }
       return group

--- a/ClashMax/Stores/PublicIPCoordinator.swift
+++ b/ClashMax/Stores/PublicIPCoordinator.swift
@@ -39,17 +39,17 @@ final class PublicIPCoordinator {
       do {
         let info = try await self.client.fetchPublicIPInfo()
         guard !Task.isCancelled else { return }
-        self.state = .loaded(info)
+        state = .loaded(info)
       } catch is CancellationError {
       } catch {
         guard !Task.isCancelled else { return }
-        self.state = .failed(
+        state = .failed(
           message: UserFacingError.message(for: error),
           previous: previous,
           failedAt: Date()
         )
       }
-      self.task = nil
+      task = nil
     }
   }
 

--- a/ClashMax/Stores/RuntimeSnippetLibraryStore.swift
+++ b/ClashMax/Stores/RuntimeSnippetLibraryStore.swift
@@ -52,7 +52,7 @@ final class RuntimeSnippetLibraryStore {
     paths: RuntimePaths,
     diskIO: any RuntimeSnippetLibraryDiskIOProviding = RuntimeSnippetLibraryDiskIO()
   ) {
-    self.libraryURL = paths.runtimeSnippetLibraryURL
+    libraryURL = paths.runtimeSnippetLibraryURL
     self.diskIO = diskIO
     loadTask = Task { [weak self] in
       await self?.loadFromDisk()

--- a/ClashMax/Support/Formatters.swift
+++ b/ClashMax/Support/Formatters.swift
@@ -8,4 +8,3 @@ enum DisplayFormatters {
     return formatter
   }()
 }
-

--- a/ClashMax/Support/RuntimePaths.swift
+++ b/ClashMax/Support/RuntimePaths.swift
@@ -201,7 +201,7 @@ enum UserFacingError {
       return networkMessage
     }
 
-    if localized.contains("The operation couldn") && !described.isEmpty {
+    if localized.contains("The operation couldn"), !described.isEmpty {
       return message(from: described)
     }
     return message(from: localized)
@@ -231,7 +231,8 @@ enum UserFacingError {
     let helperRegistrationFailed = domain == "SMAppServiceErrorDomain" && code == 3
     if helperRegistrationFailed
       || message.localizedCaseInsensitiveContains("Codesigning failure")
-      || message.contains("-67056") {
+      || message.contains("-67056")
+    {
       return helperCodeSigningRecovery
     }
     return nil

--- a/ClashMax/Views/ConnectionsView.swift
+++ b/ClashMax/Views/ConnectionsView.swift
@@ -501,9 +501,9 @@ private struct ConnectionSearchQuery {
       connection.network,
       connection.rule,
       connection.rulePayload,
-      connection.chain.joined(separator: " ")
+      connection.chain.joined(separator: " "),
     ]
-    .compactMap { $0 }
+    .compactMap(\.self)
     .joined(separator: " ")
     return terms.allSatisfy { haystack.localizedCaseInsensitiveContains($0) }
   }

--- a/ClashMax/Views/ContentView.swift
+++ b/ClashMax/Views/ContentView.swift
@@ -25,32 +25,32 @@ struct ContentView: View {
         }
         .clipped()
       }
-        .toolbar {
-          // Deliberately the default placement, not `.navigation`: `.navigation` sits
-          // *before* the window title and pushes the app name off the leading edge.
-          // The title owns the leading edge, these global runtime controls own the
-          // trailing side, and they are the only things in here — per-page controls
-          // stay inside the page (see `AdaptivePage.pageActionBar`) so they never read
-          // as an extension of the run-mode picker.
-          ToolbarItemGroup {
-            RunModePicker(selection: Binding(
-              get: { appModel.overrides.mode },
-              set: { appModel.requestMode($0) }
-            ))
+      .toolbar {
+        // Deliberately the default placement, not `.navigation`: `.navigation` sits
+        // *before* the window title and pushes the app name off the leading edge.
+        // The title owns the leading edge, these global runtime controls own the
+        // trailing side, and they are the only things in here — per-page controls
+        // stay inside the page (see `AdaptivePage.pageActionBar`) so they never read
+        // as an extension of the run-mode picker.
+        ToolbarItemGroup {
+          RunModePicker(selection: Binding(
+            get: { appModel.overrides.mode },
+            set: { appModel.requestMode($0) }
+          ))
 
-            Button {
-              if appModel.canStopRuntime {
-                appModel.stop()
-              } else {
-                appModel.start()
-              }
-            } label: {
-              Label(toolbarRunTitle, systemImage: toolbarRunSymbol)
+          Button {
+            if appModel.canStopRuntime {
+              appModel.stop()
+            } else {
+              appModel.start()
             }
-            .keyboardShortcut("r", modifiers: [.command])
-            .disabled(!appModel.canStopRuntime && appModel.readinessIssue != nil)
+          } label: {
+            Label(toolbarRunTitle, systemImage: toolbarRunSymbol)
           }
+          .keyboardShortcut("r", modifiers: [.command])
+          .disabled(!appModel.canStopRuntime && appModel.readinessIssue != nil)
         }
+      }
     }
     .sheet(isPresented: initialTunHelperPromptPresented) {
       if let prompt = appModel.initialTunHelperPrompt {
@@ -205,7 +205,6 @@ private struct InitialTunHelperPromptSheet: View {
     }
   }
 
-  @ViewBuilder
   private var statusLine: some View {
     HStack(alignment: .firstTextBaseline, spacing: 8) {
       if prompt.isWaitingOnSystemSettings {
@@ -382,13 +381,13 @@ enum StatusStripSupplemental {
       switch tone {
       case .info:
         return .blue
-        case .success:
-          return .green
-        case .warning:
-          return .orange
-        }
+      case .success:
+        return .green
+      case .warning:
+        return .orange
       }
     }
+  }
 }
 
 struct StatusStripContent: View {

--- a/ClashMax/Views/Dashboard/DashboardComponents.swift
+++ b/ClashMax/Views/Dashboard/DashboardComponents.swift
@@ -362,11 +362,11 @@ private struct DiagnosticEventList: View {
     let context = [
       event.flowProtocol?.displayName,
       event.remoteEndpoint,
-      event.sourceAppSigningIdentifier.map { "source=\($0)" }
+      event.sourceAppSigningIdentifier.map { "source=\($0)" },
     ]
-      .compactMap { $0 }
-      .filter { !$0.isEmpty }
-      .joined(separator: " ")
+    .compactMap(\.self)
+    .filter { !$0.isEmpty }
+    .joined(separator: " ")
     if !context.isEmpty {
       return "\(event.message) \(context)"
     }

--- a/ClashMax/Views/Dashboard/DashboardView.swift
+++ b/ClashMax/Views/Dashboard/DashboardView.swift
@@ -59,7 +59,6 @@ enum DashboardHomeBackgroundStyle {
 }
 
 private struct DashboardSceneBackground: View {
-
   var body: some View {
     Color(nsColor: .windowBackgroundColor)
       .ignoresSafeArea()

--- a/ClashMax/Views/Dashboard/LaunchDashboardView.swift
+++ b/ClashMax/Views/Dashboard/LaunchDashboardView.swift
@@ -30,9 +30,9 @@ struct LaunchDashboardView: View {
           primaryActionDisabled: primaryActionDisabled,
           primaryAction: runRuntime
         )
-          .frame(maxWidth: DashboardLayoutMetrics.launchControlsMaxWidth(availableWidth: availableSize.width))
-          .frame(maxWidth: .infinity)
-          .transition(.movingParts.blur)
+        .frame(maxWidth: DashboardLayoutMetrics.launchControlsMaxWidth(availableWidth: availableSize.width))
+        .frame(maxWidth: .infinity)
+        .transition(.movingParts.blur)
 
         LaunchStatusMessage(state: state)
           .frame(maxWidth: DashboardLayoutMetrics.launchControlsMaxWidth(availableWidth: availableSize.width))
@@ -54,8 +54,8 @@ struct LaunchDashboardView: View {
           reduceMotion: reduceMotion,
           activationTrigger: coreActivationTrigger
         )
-          .frame(width: visualSide, height: visualSide)
-          .contentShape(Circle())
+        .frame(width: visualSide, height: visualSide)
+        .contentShape(Circle())
       }
       .buttonStyle(.plain)
       .disabled(primaryActionDisabled)
@@ -198,7 +198,7 @@ private struct LaunchControlDeck: View {
 
       Picker("Profile", selection: profilePickerBinding) {
         if appModel.profileStore.profiles.isEmpty {
-          Text("No Profiles").tag(Optional<Profile.ID>.none)
+          Text("No Profiles").tag(Profile.ID?.none)
         }
         ForEach(appModel.profileStore.profiles) { profile in
           Text(profile.name).tag(Optional(profile.id))
@@ -282,7 +282,7 @@ private struct LaunchControlDeck: View {
         ),
         in: 1024...65535
       )
-        .frame(width: DashboardLayoutMetrics.launchMixedPortControlWidth, alignment: .leading)
+      .frame(width: DashboardLayoutMetrics.launchMixedPortControlWidth, alignment: .leading)
     }
     .frame(width: DashboardLayoutMetrics.launchMixedPortControlWidth, alignment: .leading)
   }

--- a/ClashMax/Views/Dashboard/PublicIPInfoCard.swift
+++ b/ClashMax/Views/Dashboard/PublicIPInfoCard.swift
@@ -328,7 +328,7 @@ struct PublicIPInfoCard: View {
     let minimum: CGFloat = isCompact ? 118 : 150
     return [
       GridItem(.flexible(minimum: minimum), spacing: 10),
-      GridItem(.flexible(minimum: minimum), spacing: 10)
+      GridItem(.flexible(minimum: minimum), spacing: 10),
     ]
   }
 
@@ -355,7 +355,7 @@ struct PublicIPInfoCard: View {
 
   private func asnISPSummary(for info: PublicIPInfo) -> String {
     [info.asn, info.isp]
-      .compactMap { $0 }
+      .compactMap(\.self)
       .filter { !$0.isEmpty }
       .joined(separator: " / ")
       .nonEmpty ?? "--"
@@ -363,7 +363,7 @@ struct PublicIPInfoCard: View {
 
   private func locationSummary(for info: PublicIPInfo) -> String {
     [info.city, info.region]
-      .compactMap { $0 }
+      .compactMap(\.self)
       .filter { !$0.isEmpty }
       .joined(separator: ", ")
       .nonEmpty ?? "--"
@@ -375,7 +375,6 @@ struct PublicIPInfoCard: View {
     }
     return String(format: "%.2f, %.2f", latitude, longitude)
   }
-
 }
 
 struct PublicIPProxyEffectPresentation: Equatable {

--- a/ClashMax/Views/Dashboard/RunningDashboardView.swift
+++ b/ClashMax/Views/Dashboard/RunningDashboardView.swift
@@ -158,8 +158,8 @@ struct RunningDashboardView: View {
   private var currentNodeIsLoading: Bool {
     if state.isStarting { return true }
     let snapshot = currentNodeCoordinator.snapshot
-    if appModel.runtimeDataLoading && snapshot.unfilteredGroups.isEmpty { return true }
-    if !snapshot.hasResolved && !appModel.visibleProxyGroups.isEmpty { return true }
+    if appModel.runtimeDataLoading, snapshot.unfilteredGroups.isEmpty { return true }
+    if !snapshot.hasResolved, !appModel.visibleProxyGroups.isEmpty { return true }
     return false
   }
 
@@ -335,7 +335,7 @@ private struct RunningHeaderCard: View {
       LazyVGrid(
         columns: [
           GridItem(.flexible(minimum: 120), spacing: 8),
-          GridItem(.flexible(minimum: 120), spacing: 8)
+          GridItem(.flexible(minimum: 120), spacing: 8),
         ],
         alignment: .leading,
         spacing: 8
@@ -440,7 +440,8 @@ enum DashboardProxySelectionState {
   static func resolvedGroup(from groups: [ProxyGroup], preferredName: String?) -> ProxyGroup? {
     let groups = selectableGroups(from: groups)
     if let preferredName,
-       let preferred = groups.first(where: { $0.name == preferredName }) {
+       let preferred = groups.first(where: { $0.name == preferredName })
+    {
       return preferred
     }
     return groups.first
@@ -1002,11 +1003,11 @@ private struct NetworkExtensionDiagnosticsRuntimeCard: View {
     let context = [
       event.flowProtocol?.displayName,
       event.remoteEndpoint,
-      event.sourceAppSigningIdentifier
+      event.sourceAppSigningIdentifier,
     ]
-      .compactMap { $0 }
-      .filter { !$0.isEmpty }
-      .joined(separator: " ")
+    .compactMap(\.self)
+    .filter { !$0.isEmpty }
+    .joined(separator: " ")
     return context.isEmpty ? event.message : context
   }
 }
@@ -1035,7 +1036,7 @@ struct StatusView: View {
 
             StatusHelperDiagnosticsCard()
 
-            if showsTunDiagnostics && showsNetworkExtensionDiagnostics {
+            if showsTunDiagnostics, showsNetworkExtensionDiagnostics {
               StatusResponsivePair(availableWidth: proxy.size.width) {
                 StatusTunDiagnosticsCard()
               } trailing: {
@@ -1270,7 +1271,7 @@ private struct StatusFactFlowLayout: Layout {
       var items: [FlowItem] = []
       var rowHeight: CGFloat = 0
 
-      for index in startIndex ..< startIndex + rowCount {
+      for index in startIndex..<startIndex + rowCount {
         let measuredSize = subviews[index].sizeThatFits(ProposedViewSize(width: itemWidth, height: nil))
         items.append(FlowItem(index: index, size: CGSize(width: itemWidth, height: measuredSize.height)))
         rowHeight = max(rowHeight, measuredSize.height)
@@ -1292,7 +1293,7 @@ private struct StatusFactFlowLayout: Layout {
     let baseCount = itemCount / rowCount
     let extraCount = itemCount % rowCount
 
-    return (0 ..< rowCount).map { rowIndex in
+    return (0..<rowCount).map { rowIndex in
       baseCount + (rowIndex < extraCount ? 1 : 0)
     }
   }
@@ -1882,11 +1883,11 @@ private struct StatusNetworkExtensionDiagnosticsCard: View {
     let context = [
       event.flowProtocol?.displayName,
       event.remoteEndpoint,
-      event.sourceAppSigningIdentifier
+      event.sourceAppSigningIdentifier,
     ]
-      .compactMap { $0 }
-      .filter { !$0.isEmpty }
-      .joined(separator: " ")
+    .compactMap(\.self)
+    .filter { !$0.isEmpty }
+    .joined(separator: " ")
     return context.isEmpty ? event.message : context
   }
 }

--- a/ClashMax/Views/Dashboard/TrafficSparkline.swift
+++ b/ClashMax/Views/Dashboard/TrafficSparkline.swift
@@ -36,8 +36,8 @@ struct TrafficChartGeometry: Equatable {
     let ceiling = Self.niceCeiling(atLeast: max(peak, Self.minimumCeiling))
     let divisor = Double(ceiling)
     self.ceiling = ceiling
-    self.download = window.map { min(Double($0.download) / divisor, 1) }
-    self.upload = window.map { min(Double($0.upload) / divisor, 1) }
+    download = window.map { min(Double($0.download) / divisor, 1) }
+    upload = window.map { min(Double($0.upload) / divisor, 1) }
   }
 
   private static func window(_ samples: [TrafficSample], slots: Int) -> [TrafficSample] {
@@ -118,7 +118,7 @@ struct AnimatableVector: VectorArithmetic {
     let count = max(lhs.values.count, rhs.values.count)
     var result = [Double]()
     result.reserveCapacity(count)
-    for index in 0 ..< count {
+    for index in 0..<count {
       let left = index < lhs.values.count ? lhs.values[index] : 0
       let right = index < rhs.values.count ? rhs.values[index] : 0
       result.append(operation(left, right))
@@ -162,7 +162,7 @@ struct TrafficSeriesShape: Shape {
     }
 
     path.move(to: points[0])
-    for index in 0 ..< (points.count - 1) {
+    for index in 0..<(points.count - 1) {
       let previous = points[max(index - 1, 0)]
       let start = points[index]
       let end = points[index + 1]

--- a/ClashMax/Views/MenuBarView.swift
+++ b/ClashMax/Views/MenuBarView.swift
@@ -20,7 +20,7 @@ enum MenuBarPanelLayout {
   static let statusCornerRadius: CGFloat = 8
   static let trafficChartHeight: CGFloat = 52
   static let footerButtonMinWidth: CGFloat = 0
-  static let plannedWidthRange: ClosedRange<CGFloat> = 300 ... 330
+  static let plannedWidthRange: ClosedRange<CGFloat> = 300...330
 }
 
 /// The whole panel presented by `MenuBarExtra(...).menuBarExtraStyle(.window)`.
@@ -194,7 +194,6 @@ struct MenuBarView: View {
         }
 
         HStack(spacing: 5) {
-
           Button {
             NSApp.terminate(nil)
           } label: {

--- a/ClashMax/Views/ProfilesView.swift
+++ b/ClashMax/Views/ProfilesView.swift
@@ -281,7 +281,7 @@ struct ProfilesView: View {
         .adaptive(minimum: 280, maximum: 360),
         spacing: 12,
         alignment: .topLeading
-      )
+      ),
     ]
   }
 
@@ -476,7 +476,7 @@ struct ProfilesView: View {
         for candidate in report.subscriptions {
           var importedProviderOptions = candidate.providerOptions
           if options.importRuleSnippets {
-            importedProviderOptions = self.providerOptionsByApplyingRuleSnippets(
+            importedProviderOptions = providerOptionsByApplyingRuleSnippets(
               importedProviderOptions,
               applyingRuleSnippets: report.ruleSnippets.filter { $0.profileSourceID == candidate.id }
             )
@@ -580,7 +580,8 @@ struct ProfilesView: View {
   ) async {
     for candidate in snippets {
       if let profileSourceID = candidate.profileSourceID,
-         subscriptionSourceIDs.contains(profileSourceID) {
+         subscriptionSourceIDs.contains(profileSourceID)
+      {
         continue
       }
       let binding: RuntimeSnippetBinding
@@ -692,7 +693,7 @@ private struct ClientMigrationReportSheet: View {
             )
           )
         }
-          .keyboardShortcut(.defaultAction)
+        .keyboardShortcut(.defaultAction)
       }
     }
   }
@@ -700,7 +701,7 @@ private struct ClientMigrationReportSheet: View {
   private var sourceValues: [String] {
     [
       "Client: \(report.client.displayName)",
-      "Directory: \(report.configDirectory)"
+      "Directory: \(report.configDirectory)",
     ]
   }
 
@@ -734,9 +735,9 @@ private struct ClientMigrationReportSheet: View {
       report.systemProxyEnabled.map { "system proxy intent: \($0)" },
       report.ports.isEmpty ? nil : report.ports.map { "\($0.key): \($0.value)" }.sorted().joined(separator: ", "),
       report.bypassDomains.isEmpty ? nil : "bypass: \(report.bypassDomains.joined(separator: ", "))",
-      shortcutValues.isEmpty ? nil : "shortcuts: \(shortcutValues.joined(separator: ", "))"
+      shortcutValues.isEmpty ? nil : "shortcuts: \(shortcutValues.joined(separator: ", "))",
     ]
-    .compactMap { $0 }
+    .compactMap(\.self)
   }
 
   private var shortcutValues: [String] {
@@ -970,7 +971,7 @@ private struct ProfileMetricsRow: View {
   private var columns: [GridItem] {
     [
       GridItem(.flexible(minimum: 92), spacing: 8, alignment: .topLeading),
-      GridItem(.flexible(minimum: 92), spacing: 8, alignment: .topLeading)
+      GridItem(.flexible(minimum: 92), spacing: 8, alignment: .topLeading),
     ]
   }
 
@@ -1097,7 +1098,7 @@ private struct ProviderInsightsMetricGrid: View {
       GridItem(.flexible(minimum: 130), spacing: 10, alignment: .topLeading),
       GridItem(.flexible(minimum: 130), spacing: 10, alignment: .topLeading),
       GridItem(.flexible(minimum: 130), spacing: 10, alignment: .topLeading),
-      GridItem(.flexible(minimum: 130), spacing: 10, alignment: .topLeading)
+      GridItem(.flexible(minimum: 130), spacing: 10, alignment: .topLeading),
     ]
   }
 
@@ -1329,7 +1330,8 @@ private struct ProfileEditSheet: View {
           }
 
           if let upstreamEndpoint = outboundProxyEndpoints.first(where: { $0.id == upstreamEndpointID }),
-             upstreamEndpoint.isTCPOnly {
+             upstreamEndpoint.isTCPOnly
+          {
             ProfileEditContentRow {
               Label(
                 "TCP Only: System Proxy does not capture UDP; TUN and Network Extension reject UDP for this profile.",
@@ -1932,7 +1934,7 @@ private struct SubscriptionDiagnosticsView: View {
   private var diagnosticColumns: [GridItem] {
     [
       GridItem(.flexible(minimum: 170), spacing: 10, alignment: .topLeading),
-      GridItem(.flexible(minimum: 170), spacing: 10, alignment: .topLeading)
+      GridItem(.flexible(minimum: 170), spacing: 10, alignment: .topLeading),
     ]
   }
 

--- a/ClashMax/Views/ProxiesView.swift
+++ b/ClashMax/Views/ProxiesView.swift
@@ -477,12 +477,12 @@ private struct ProxyGroupListAnimationState: Equatable {
     searchQuery: String,
     sortOrder: ProxyNodeSort
   ) {
-    self.groupIDs = groups.map(\.id)
+    groupIDs = groups.map(\.id)
     self.expandedGroupIDs = expandedGroupIDs.sorted()
-    self.nodeIDsByGroup = groups.map { group in
+    nodeIDsByGroup = groups.map { group in
       group.nodes.map(\.id)
     }
-    self.selections = groups.map { group in
+    selections = groups.map { group in
       group.selected ?? ""
     }
     self.searchQuery = searchQuery
@@ -530,7 +530,7 @@ enum ProxyGroupExpansionPolicy {
       return defaultExpandedIDs(for: groups)
     }
     let retained = current.intersection(groupIDs)
-    if !current.isEmpty && retained.isEmpty {
+    if !current.isEmpty, retained.isEmpty {
       return defaultExpandedIDs(for: groups)
     }
     return retained
@@ -540,7 +540,7 @@ enum ProxyGroupExpansionPolicy {
     guard let current else { return nil }
     let groupIDs = Set(groups.map(\.id))
     let retained = current.intersection(groupIDs)
-    if !current.isEmpty && retained.isEmpty {
+    if !current.isEmpty, retained.isEmpty {
       return defaultExpandedIDs(for: groups)
     }
     return retained
@@ -616,7 +616,7 @@ enum ProxyGroupSelectionPolicy {
   }
 }
 
-struct ProxyGroupSearchFilter {
+enum ProxyGroupSearchFilter {
   static func filteredGroups(from groups: [ProxyGroup], searchQuery: ProxySearchQuery) -> [ProxyGroup] {
     guard !searchQuery.isEmpty else { return groups }
     return groups.compactMap { group in
@@ -650,9 +650,9 @@ struct ProxySearchQuery: Equatable, Sendable {
         parsedTerms.append(term)
       }
     }
-    self.terms = parsedTerms
-    self.isCaseSensitive = parsedCaseSensitive
-    self.isWholeWord = parsedWholeWord
+    terms = parsedTerms
+    isCaseSensitive = parsedCaseSensitive
+    isWholeWord = parsedWholeWord
   }
 
   var isEmpty: Bool {
@@ -716,9 +716,9 @@ struct ProxySearchQuery: Equatable, Sendable {
       node.name,
       node.type,
       node.providerName,
-      node.endpointSummary
+      node.endpointSummary,
     ]
-    .compactMap { $0 }
+    .compactMap(\.self)
     .joined(separator: " ")
   }
 
@@ -830,12 +830,12 @@ private struct ProxyGroupSplitView: View {
     customDelayTestURLText: Binding<String>
   ) {
     self.groups = groups
-    self._selectedGroupID = selectedGroupID
+    _selectedGroupID = selectedGroupID
     self.nodePresentation = nodePresentation
     self.showsNodeDetails = showsNodeDetails
     self.closesOldConnectionsAfterSwitch = closesOldConnectionsAfterSwitch
     self.isDelayBatchRunning = isDelayBatchRunning
-    self._customDelayTestURLText = customDelayTestURLText
+    _customDelayTestURLText = customDelayTestURLText
   }
 
   var body: some View {
@@ -866,7 +866,8 @@ private struct ProxyGroupSplitView: View {
 
   private var selectedGroup: ProxyGroup? {
     if let selectedGroupID,
-       let group = groups.first(where: { $0.id == selectedGroupID }) {
+       let group = groups.first(where: { $0.id == selectedGroupID })
+    {
       return group
     }
     return groups.first
@@ -937,7 +938,7 @@ private struct ProxyGroupNavigatorRow: View {
 
   private var subtitle: String {
     let selected = group.selected ?? "No selection"
-    let best = group.nodes.compactMap { $0.resolvedDelayState.measuredDelay }.min()
+    let best = group.nodes.compactMap(\.resolvedDelayState.measuredDelay).min()
     if let best {
       return "\(group.nodes.count) nodes - \(selected) - best \(best) ms"
     }
@@ -997,7 +998,6 @@ private struct ProxyGroupDetailPane: View {
     }
   }
 
-  @ViewBuilder
   private var nodeCards: some View {
     ForEach(group.nodes) { node in
       ProxyNodeCard(
@@ -1184,12 +1184,12 @@ private struct ProxyDelayBatchProgressStrip: View {
     switch progress.status {
     case .running, .completed:
       return .secondary
-      case .partiallyCompleted, .cancelled:
-        return .orange
-      case .failed:
-        return .orange
-      }
+    case .partiallyCompleted, .cancelled:
+      return .orange
+    case .failed:
+      return .orange
     }
+  }
 
   private var metrics: some View {
     HStack(spacing: 8) {
@@ -1212,11 +1212,11 @@ private struct ProxyDelayBatchProgressStrip: View {
         systemImage: ProxyDelayFailureKind.timeout.systemImage,
         color: .orange
       )
-        ProxyDelayBatchMetric(
-          text: "\(progress.failed)",
-          systemImage: ProxyDelayFailureKind.other.systemImage,
-          color: .orange
-        )
+      ProxyDelayBatchMetric(
+        text: "\(progress.failed)",
+        systemImage: ProxyDelayFailureKind.other.systemImage,
+        color: .orange
+      )
       if progress.cancelled > 0 {
         ProxyDelayBatchMetric(
           text: "\(progress.cancelled)",
@@ -1304,9 +1304,9 @@ private struct ProxyDelayBatchProgressStrip: View {
     failures: [ProxyDelayBatchFailure]
   ) -> some View {
     VStack(alignment: .leading, spacing: 3) {
-        Label("\(kind.displayName) \(count)", systemImage: kind.systemImage)
-          .font(.caption)
-          .foregroundStyle(.orange)
+      Label("\(kind.displayName) \(count)", systemImage: kind.systemImage)
+        .font(.caption)
+        .foregroundStyle(.orange)
       ForEach(failures.prefix(3)) { failure in
         Text("\(failure.displayName): \(failure.message)")
           .font(.caption2)
@@ -1497,7 +1497,7 @@ private struct ProxyGroupCard: View {
             closesOldConnectionsAfterSwitch: closesOldConnectionsAfterSwitch,
             isDelayBatchRunning: isDelayBatchRunning
           )
-            .transition(ProxyInteractionAnimation.nodeTransition(reduceMotion: reduceMotion))
+          .transition(ProxyInteractionAnimation.nodeTransition(reduceMotion: reduceMotion))
         }
       }
       .padding(10)
@@ -1564,7 +1564,7 @@ private struct ProxyGroupCard: View {
   }
 
   private var groupHeaderAccessibilityLabel: String {
-    return "\(isExpanded ? "Collapse" : "Expand") \(group.name)"
+    "\(isExpanded ? "Collapse" : "Expand") \(group.name)"
   }
 
   private var nodeCountLabel: some View {
@@ -1594,8 +1594,6 @@ private struct ProxyGroupCard: View {
         let delayDisplay = ProxyDelayDisplay(state: selectedNode.resolvedDelayState)
         Text(delayDisplay.label)
           .foregroundStyle(delayDisplay.tone.color)
-      } else {
-        EmptyView()
       }
     }
     .font(.caption.monospacedDigit())
@@ -1900,14 +1898,14 @@ struct ProxyDelayDisplay: Equatable {
     case let .measured(delay):
       label = "\(delay) ms"
       tone = ProxyDelayTone(delay: delay)
-      case .timeout:
-        label = "Timeout"
-        tone = .timeout
-      case .error:
-        label = "No result"
-        tone = .error
-      }
+    case .timeout:
+      label = "Timeout"
+      tone = .timeout
+    case .error:
+      label = "No result"
+      tone = .error
     }
+  }
 }
 
 enum ProxyDelayTone: Equatable {
@@ -1943,17 +1941,17 @@ enum ProxyDelayTone: Equatable {
       return .green
     case .good:
       return .mint
-      case .moderate:
-        return .yellow
-      case .slow:
-        return .orange
-      case .timeout:
-        return .orange
-      case .error:
-        return .orange
-      }
+    case .moderate:
+      return .yellow
+    case .slow:
+      return .orange
+    case .timeout:
+      return .orange
+    case .error:
+      return .orange
     }
   }
+}
 
 private struct DelayChip: View {
   let display: ProxyDelayDisplay

--- a/ClashMax/Views/ProxySearchCoordinator.swift
+++ b/ClashMax/Views/ProxySearchCoordinator.swift
@@ -45,7 +45,7 @@ final class ProxySearchCoordinator {
 
   init(run: @escaping @Sendable (ProxySearchPipeline.Input) -> ProxySearchSnapshot = { ProxySearchPipeline.run($0) }) {
     self.run = run
-    self.signposter = OSSignposter(logger: logger)
+    signposter = OSSignposter(logger: logger)
   }
 
   /// Schedule a search. Any in-flight request is cancelled so only the newest generation publishes.
@@ -55,8 +55,8 @@ final class ProxySearchCoordinator {
     isComputing = true
 
     let debounce = debounceInterval(for: reason)
-    let run = self.run
-    let signposter = self.signposter
+    let run = run
+    let signposter = signposter
 
     let task = Task { [weak self] in
       defer { self?.pending[token] = nil }

--- a/ClashMax/Views/ProxySearchPipeline.swift
+++ b/ClashMax/Views/ProxySearchPipeline.swift
@@ -186,7 +186,8 @@ struct ResolvedProxyCatalog {
         if node.type.caseInsensitiveCompare("provider") == .orderedSame,
            let providerName = Self.providerName(from: node),
            let nodes = providerNodes[providerName],
-           !nodes.isEmpty {
+           !nodes.isEmpty
+        {
           expandedNodes.append(contentsOf: nodes.map { providerNode in
             var providerNode = providerNode
             providerNode.isSelectable = group.allowsManualProxySelection
@@ -256,10 +257,10 @@ struct ProxySearchInputSignature: Equatable {
         nodeCount += 1
       }
     }
-    self.groupCount = groups.count
-    self.providerCount = providers.count
+    groupCount = groups.count
+    providerCount = providers.count
     self.nodeCount = nodeCount
-    self.contentHash = hasher.finalize()
+    contentHash = hasher.finalize()
   }
 
   private static func combine(node: ProxyNode, into hasher: inout Hasher) {

--- a/ClashMax/Views/QuickRuleSheet.swift
+++ b/ClashMax/Views/QuickRuleSheet.swift
@@ -188,7 +188,6 @@ struct QuickRuleSheet: View {
 
   /// The point of phase B3: after applying, say what the rule actually does now — including the
   /// case that matters most, a rule that is live but loses to something earlier in the list.
-  @ViewBuilder
   private var verdictSection: some View {
     VStack(alignment: .leading, spacing: 6) {
       Text("Effect")
@@ -263,7 +262,8 @@ struct QuickRuleSheet: View {
     var seen = Set<String>()
     var suggestions: [String] = []
     for name in runtimeData.proxyGroups.map(\.name) + ["DIRECT", "REJECT", "REJECT-DROP", "PASS"]
-    where !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+      where !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    {
       if seen.insert(name.uppercased()).inserted {
         suggestions.append(name)
       }
@@ -452,7 +452,7 @@ enum QuickRuleVerdict: Equatable {
       (String(localized: "destination port"), input.destinationPort),
       (String(localized: "source port"), input.sourcePort),
       (String(localized: "inbound port"), input.inboundPort),
-      (String(localized: "process"), input.process)
+      (String(localized: "process"), input.process),
     ]
     let described = fields
       .filter { !$0.1.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }

--- a/ClashMax/Views/RoutingView.swift
+++ b/ClashMax/Views/RoutingView.swift
@@ -62,7 +62,7 @@ final class RuleMatchSimulationDebouncer {
         return
       }
       guard let self, !Task.isCancelled else { return }
-      self.task = nil
+      task = nil
       action()
     }
   }
@@ -436,12 +436,12 @@ struct RoutingView: View {
         RuntimeDNSPatchEditor(settings: dnsPayloadBinding)
       }
 
-        if let validationError = draftSnippet.validationError {
-          Label(validationError, systemImage: "exclamationmark.triangle.fill")
-            .font(.caption)
-            .foregroundStyle(.orange)
-            .lineLimit(3)
-        }
+      if let validationError = draftSnippet.validationError {
+        Label(validationError, systemImage: "exclamationmark.triangle.fill")
+          .font(.caption)
+          .foregroundStyle(.orange)
+          .lineLimit(3)
+      }
     }
   }
 
@@ -551,7 +551,7 @@ struct RoutingView: View {
         LazyVGrid(
           columns: [
             GridItem(.flexible(minimum: 96), spacing: 10, alignment: .leading),
-            GridItem(.flexible(minimum: 96), spacing: 10, alignment: .leading)
+            GridItem(.flexible(minimum: 96), spacing: 10, alignment: .leading),
           ],
           alignment: .leading,
           spacing: 8
@@ -569,7 +569,7 @@ struct RoutingView: View {
       RoutingCompactFact(title: "Profile", value: profileStore.activeProfile?.name ?? String(localized: "No Profile")),
       RoutingCompactFact(title: "Snippet Binding", value: draftSnippet.binding.displayName),
       RoutingCompactFact(title: "Applies Here", value: draftAppliesToActiveProfile ? String(localized: "Yes") : String(localized: "No")),
-      RoutingCompactFact(title: "Active Snippets", value: "\(activePreviewSnippets.count)")
+      RoutingCompactFact(title: "Active Snippets", value: "\(activePreviewSnippets.count)"),
     ]
   }
 
@@ -984,7 +984,8 @@ struct RoutingView: View {
     guard let activeProfileID = profileStore.activeProfileID else { return [] }
     var snippets = snippetLibrary.snippets
     if let selectedSnippetID,
-       let index = snippets.firstIndex(where: { $0.id == selectedSnippetID }) {
+       let index = snippets.firstIndex(where: { $0.id == selectedSnippetID })
+    {
       snippets[index] = draftSnippet
     } else if selectedSnippet == nil {
       snippets.append(draftSnippet)
@@ -1077,7 +1078,8 @@ struct RoutingView: View {
 
   private func reconcileDraftWithLibrary() {
     if let selectedSnippetID,
-       let snippet = snippetLibrary.snippets.first(where: { $0.id == selectedSnippetID }) {
+       let snippet = snippetLibrary.snippets.first(where: { $0.id == selectedSnippetID })
+    {
       if snippet == draftSnippet {
         loadedSnippetSnapshot = snippet
       } else if !draftHasUnsavedChanges {
@@ -1648,7 +1650,7 @@ private struct RoutingCompactFact: Identifiable {
   let value: String
 
   init(title: LocalizedStringResource, value: String) {
-    self.id = String(localized: title)
+    id = String(localized: title)
     self.title = title
     self.value = value
   }

--- a/ClashMax/Views/RulesView.swift
+++ b/ClashMax/Views/RulesView.swift
@@ -185,7 +185,7 @@ private struct RuleSearchQuery {
         return (rule.providerName ?? "").localizedCaseInsensitiveContains(value(after: "provider=", in: term))
       }
       return [rule.type, rule.payload, rule.policy, rule.providerName, rule.raw]
-        .compactMap { $0 }
+        .compactMap(\.self)
         .joined(separator: " ")
         .localizedCaseInsensitiveContains(term)
     }
@@ -307,9 +307,9 @@ private struct RuleProviderList: View {
       provider.vehicleType,
       provider.behavior,
       provider.format,
-      provider.ruleCount.map { "\($0) rules" }
+      provider.ruleCount.map { "\($0) rules" },
     ]
-    .compactMap { $0 }
+    .compactMap(\.self)
     .filter { !$0.isEmpty }
     .joined(separator: " - ")
   }

--- a/ClashMax/Views/SettingsView.swift
+++ b/ClashMax/Views/SettingsView.swift
@@ -151,7 +151,6 @@ struct SettingsView: View {
             }
             .help("Open System Settings > General > Login Items & Extensions.")
           }
-
         }
 
         if appModel.developerMode {
@@ -413,11 +412,11 @@ struct SettingsView: View {
                   appModel.resolveCurrentNetworkSSIDAvailability()
                 }
               )
-                .frame(width: 560)
-                .padding(18)
-                .onAppear {
-                  appModel.refreshCurrentNetworkPolicyState()
-                }
+              .frame(width: 560)
+              .padding(18)
+              .onAppear {
+                appModel.refreshCurrentNetworkPolicyState()
+              }
             }
           }
 
@@ -1075,10 +1074,10 @@ private struct NetworkPolicySettingsPopover: View {
           statusMessage ?? String(localized: "Current network not checked."),
           systemImage: currentNetwork.statusSymbolName
         )
-          .font(.caption)
-          .foregroundStyle(currentNetwork.isBlockedByLocationAuthorization ? .orange : .secondary)
-          .lineLimit(2)
-          .fixedSize(horizontal: false, vertical: true)
+        .font(.caption)
+        .foregroundStyle(currentNetwork.isBlockedByLocationAuthorization ? .orange : .secondary)
+        .lineLimit(2)
+        .fixedSize(horizontal: false, vertical: true)
         Spacer()
         if let recoveryTitle = NetworkPolicyStatusPresenter.recoveryActionTitle(for: currentNetwork) {
           Button(recoveryTitle) {
@@ -1125,12 +1124,12 @@ private struct NetworkPolicySettingsPopover: View {
           .toggleStyle(.checkbox)
 
         HStack {
-            if let error = draftRule.validationError {
-              Label(error, systemImage: "exclamationmark.triangle.fill")
-                .font(.caption)
-                .foregroundStyle(.orange)
-                .lineLimit(2)
-            }
+          if let error = draftRule.validationError {
+            Label(error, systemImage: "exclamationmark.triangle.fill")
+              .font(.caption)
+              .foregroundStyle(.orange)
+              .lineLimit(2)
+          }
           Spacer()
           Button {
             addRule()
@@ -1313,7 +1312,7 @@ private struct ExternalDashboardProfilesPopover: View {
                   .foregroundStyle(.secondary)
                   .help("Secret stored in Keychain")
               }
-              if !profile.readOnly && profile.trustedForSecretAutofill {
+              if !profile.readOnly, profile.trustedForSecretAutofill {
                 Image(systemName: "shield.checkered")
                   .foregroundStyle(.secondary)
                   .help("Trusted for automatic secret autofill")
@@ -1370,7 +1369,7 @@ struct RuleOverlayDraftPopover: View {
     self.isApplying = isApplying
     self.errorMessage = errorMessage
     self.onApply = onApply
-    self._draft = State(initialValue: baseline)
+    _draft = State(initialValue: baseline)
   }
 
   private var pendingChangeCount: Int {
@@ -1466,7 +1465,7 @@ struct RuleOverlaySettingsEditor: View {
     showsHeader: Bool = true,
     showsEnableToggle: Bool = true
   ) {
-    self._settings = settings
+    _settings = settings
     self.showsHeader = showsHeader
     self.showsEnableToggle = showsEnableToggle
   }
@@ -1575,12 +1574,12 @@ struct RuleOverlaySettingsEditor: View {
         }
 
         HStack {
-            if let error = draftRule.validationError {
-              Label(error, systemImage: "exclamationmark.triangle.fill")
-                .font(.caption)
-                .foregroundStyle(.orange)
-                .lineLimit(2)
-            }
+          if let error = draftRule.validationError {
+            Label(error, systemImage: "exclamationmark.triangle.fill")
+              .font(.caption)
+              .foregroundStyle(.orange)
+              .lineLimit(2)
+          }
           Spacer()
           Button {
             addRule()
@@ -1607,12 +1606,12 @@ struct RuleOverlaySettingsEditor: View {
           .textFieldStyle(.roundedBorder)
 
         HStack {
-            if let error = draftDisabledRuleMatcher.validationError {
-              Label(error, systemImage: "exclamationmark.triangle.fill")
-                .font(.caption)
-                .foregroundStyle(.orange)
-                .lineLimit(2)
-            }
+          if let error = draftDisabledRuleMatcher.validationError {
+            Label(error, systemImage: "exclamationmark.triangle.fill")
+              .font(.caption)
+              .foregroundStyle(.orange)
+              .lineLimit(2)
+          }
           Spacer()
           Button {
             addDisabledRuleMatcher()
@@ -2027,10 +2026,10 @@ private struct RuleOverlayEditableRuleRow: View {
         )
       }
 
-        Text(rule.runtimeRule)
-          .font(.system(.caption2, design: .monospaced))
-          .foregroundStyle(rule.validationError == nil ? Color.secondary : Color.orange)
-          .lineLimit(1)
+      Text(rule.runtimeRule)
+        .font(.system(.caption2, design: .monospaced))
+        .foregroundStyle(rule.validationError == nil ? Color.secondary : Color.orange)
+        .lineLimit(1)
         .truncationMode(.middle)
     }
     .padding(.horizontal, 8)
@@ -2961,7 +2960,6 @@ private struct ExternalControlSettingsSheet: View {
     }
   }
 
-  @ViewBuilder
   private func labeledField<Content: View>(_ title: String, @ViewBuilder content: () -> Content) -> some View {
     HStack(alignment: .center, spacing: 14) {
       Text(localizedSettingsText(title))

--- a/ClashMax/Views/SidebarView.swift
+++ b/ClashMax/Views/SidebarView.swift
@@ -14,4 +14,3 @@ struct SidebarView: View {
     .navigationTitle("ClashMax")
   }
 }
-

--- a/ClashMaxNetworkExtension/TransparentProxyProvider.swift
+++ b/ClashMaxNetworkExtension/TransparentProxyProvider.swift
@@ -13,7 +13,7 @@ final class TransparentProxyProvider: NETransparentProxyProvider, @unchecked Sen
     NetworkExtensionRuntimeConstants.providerBundleIdentifier,
     NetworkExtensionRuntimeConstants.mihomoSigningIdentifier,
     NetworkExtensionRuntimeConstants.mihomoArm64SigningIdentifier,
-    NetworkExtensionRuntimeConstants.mihomoAmd64SigningIdentifier
+    NetworkExtensionRuntimeConstants.mihomoAmd64SigningIdentifier,
   ]
 
   private let lock = NSLock()
@@ -96,7 +96,7 @@ final class TransparentProxyProvider: NETransparentProxyProvider, @unchecked Sen
         localPrefix: 0,
         protocol: .UDP,
         direction: .outbound
-      )
+      ),
     ]
     settings.excludedNetworkRules = excludedNetworkRules
 
@@ -674,7 +674,8 @@ private final class NetworkExtensionDiagnosticsRecorder: @unchecked Sendable {
       try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
       var snapshotToPersist = snapshot
       if preservesExternalSystemDNSState,
-         let persistedSnapshot = Self.persistedSnapshot(at: fileURL) {
+         let persistedSnapshot = Self.persistedSnapshot(at: fileURL)
+      {
         snapshotToPersist.systemDNSOverrideApplied = persistedSnapshot.systemDNSOverrideApplied
         snapshotToPersist.systemDNSOverrideStatus = persistedSnapshot.systemDNSOverrideStatus
       }
@@ -733,11 +734,11 @@ private final class TCPFlowBridge: FlowBridge, @unchecked Sendable {
     self.id = id
     self.flow = flow
     self.endpoint = endpoint
-    self.queue = DispatchQueue(label: "io.github.clashmax.network-extension.tcp-flow.\(id.uuidString)")
+    queue = DispatchQueue(label: "io.github.clashmax.network-extension.tcp-flow.\(id.uuidString)")
     self.onError = onError
     self.onClose = onClose
     let port = NWEndpoint.Port(rawValue: UInt16(clamping: socksPort)) ?? NWEndpoint.Port(integerLiteral: 7890)
-    self.connection = NWConnection(host: NWEndpoint.Host(socksHost), port: port, using: .tcp)
+    connection = NWConnection(host: NWEndpoint.Host(socksHost), port: port, using: .tcp)
   }
 
   func start() {
@@ -745,7 +746,7 @@ private final class TCPFlowBridge: FlowBridge, @unchecked Sendable {
       guard let self else { return }
       switch state {
       case .ready:
-        self.performSocksHandshake { result in
+        performSocksHandshake { result in
           switch result {
           case .success:
             self.openFlowAndCopy()
@@ -756,9 +757,9 @@ private final class TCPFlowBridge: FlowBridge, @unchecked Sendable {
           }
         }
       case let .failed(error):
-        self.close(error)
+        close(error)
       case .cancelled:
-        self.close(nil)
+        close(nil)
       default:
         break
       }
@@ -777,7 +778,7 @@ private final class TCPFlowBridge: FlowBridge, @unchecked Sendable {
         completion(.failure(error))
         return
       }
-      self.receiveExact(length: 2) { greetingResult in
+      receiveExact(length: 2) { greetingResult in
         switch greetingResult {
         case let .failure(error):
           completion(.failure(error))
@@ -800,7 +801,7 @@ private final class TCPFlowBridge: FlowBridge, @unchecked Sendable {
         if let error {
           completion(.failure(error))
         } else {
-          self.readSocksReply { result in
+          readSocksReply { result in
             completion(result.map { _ in () })
           }
         }
@@ -825,7 +826,7 @@ private final class TCPFlowBridge: FlowBridge, @unchecked Sendable {
           completion(.failure(Socks5ReplyError.failureReply(header[1])))
           return
         }
-        self.readSocksReplyAddress(addressType: header[3]) { addressResult in
+        readSocksReplyAddress(addressType: header[3]) { addressResult in
           switch addressResult {
           case let .failure(error):
             completion(.failure(error))
@@ -833,7 +834,7 @@ private final class TCPFlowBridge: FlowBridge, @unchecked Sendable {
             var response = header
             response.append(addressData)
             do {
-              completion(.success(try Socks5ReplyParser.parse(response)))
+              try completion(.success(Socks5ReplyParser.parse(response)))
             } catch {
               completion(.failure(error))
             }
@@ -858,7 +859,7 @@ private final class TCPFlowBridge: FlowBridge, @unchecked Sendable {
           completion(.failure(error))
         case let .success(lengthBytes):
           let length = Int(lengthBytes[0])
-          self.receiveExact(length: length + 2) { result in
+          receiveExact(length: length + 2) { result in
             completion(result.map { remainder in
               var data = lengthBytes
               data.append(remainder)
@@ -899,7 +900,7 @@ private final class TCPFlowBridge: FlowBridge, @unchecked Sendable {
       } else if isComplete {
         completion(.failure(BridgeError.make("SOCKS5 server closed before sending enough data.")))
       } else {
-        self.receiveExact(length: length, accumulated: next, completion: completion)
+        receiveExact(length: length, accumulated: next, completion: completion)
       }
     }
   }
@@ -908,11 +909,11 @@ private final class TCPFlowBridge: FlowBridge, @unchecked Sendable {
     flow.open(withLocalFlowEndpoint: nil) { [weak self] error in
       guard let self else { return }
       if let error {
-        self.close(error)
+        close(error)
         return
       }
-      self.copyFlowToConnection()
-      self.copyConnectionToFlow()
+      copyFlowToConnection()
+      copyConnectionToFlow()
     }
   }
 
@@ -920,19 +921,19 @@ private final class TCPFlowBridge: FlowBridge, @unchecked Sendable {
     flow.readData { [weak self] data, error in
       guard let self else { return }
       if let error {
-        self.close(error)
+        close(error)
         return
       }
       guard let data, !data.isEmpty else {
-        self.connection.send(content: nil, isComplete: true, completion: .contentProcessed { _ in })
+        connection.send(content: nil, isComplete: true, completion: .contentProcessed { _ in })
         return
       }
-      self.connection.send(content: data, completion: .contentProcessed { [weak self] error in
+      connection.send(content: data, completion: .contentProcessed { [weak self] error in
         guard let self else { return }
         if let error {
-          self.close(error)
+          close(error)
         } else {
-          self.copyFlowToConnection()
+          copyFlowToConnection()
         }
       })
     }
@@ -942,24 +943,24 @@ private final class TCPFlowBridge: FlowBridge, @unchecked Sendable {
     connection.receive(minimumIncompleteLength: 1, maximumLength: 65_536) { [weak self] data, _, isComplete, error in
       guard let self else { return }
       if let error {
-        self.close(error)
+        close(error)
         return
       }
       if let data, !data.isEmpty {
-        self.flow.write(data) { [weak self] error in
+        flow.write(data) { [weak self] error in
           guard let self else { return }
           if let error {
-            self.close(error)
+            close(error)
           } else if isComplete {
-            self.close(nil)
+            close(nil)
           } else {
-            self.copyConnectionToFlow()
+            copyConnectionToFlow()
           }
         }
       } else if isComplete {
-        self.close(nil)
+        close(nil)
       } else {
-        self.copyConnectionToFlow()
+        copyConnectionToFlow()
       }
     }
   }
@@ -1033,13 +1034,13 @@ private final class UDPFlowBridge: FlowBridge, @unchecked Sendable {
     self.initialEndpoint = initialEndpoint
     self.dnsCapturePolicy = dnsCapturePolicy
     self.socksHost = socksHost
-    self.queue = DispatchQueue(label: "io.github.clashmax.network-extension.udp-flow.\(id.uuidString)")
+    queue = DispatchQueue(label: "io.github.clashmax.network-extension.udp-flow.\(id.uuidString)")
     self.onDatagram = onDatagram
     self.onDNSRetargetFailure = onDNSRetargetFailure
     self.onError = onError
     self.onClose = onClose
     let port = NWEndpoint.Port(rawValue: UInt16(clamping: socksPort)) ?? NWEndpoint.Port(integerLiteral: 7890)
-    self.controlConnection = NWConnection(host: NWEndpoint.Host(socksHost), port: port, using: .tcp)
+    controlConnection = NWConnection(host: NWEndpoint.Host(socksHost), port: port, using: .tcp)
   }
 
   func start() {
@@ -1050,10 +1051,10 @@ private final class UDPFlowBridge: FlowBridge, @unchecked Sendable {
 
     controlConnection.stateUpdateHandler = { [weak self] state in
       guard let self else { return }
-      guard self.isOpen() else { return }
+      guard isOpen() else { return }
       switch state {
       case .ready:
-        self.performSocksHandshake { result in
+        performSocksHandshake { result in
           switch result {
           case let .success(reply):
             self.startUDPRelay(reply: reply)
@@ -1064,9 +1065,9 @@ private final class UDPFlowBridge: FlowBridge, @unchecked Sendable {
           }
         }
       case let .failed(error):
-        self.close(error)
+        close(error)
       case .cancelled:
-        self.close(nil)
+        close(nil)
       default:
         break
       }
@@ -1081,12 +1082,12 @@ private final class UDPFlowBridge: FlowBridge, @unchecked Sendable {
   private func performSocksHandshake(completion: @escaping @Sendable (Result<Socks5Reply, Error>) -> Void) {
     controlConnection.send(content: Socks5ConnectRequest.noAuthenticationGreeting, completion: .contentProcessed { [weak self] error in
       guard let self else { return }
-      guard self.isOpen() else { return }
+      guard isOpen() else { return }
       if let error {
         completion(.failure(error))
         return
       }
-      self.receiveExact(length: 2) { greetingResult in
+      receiveExact(length: 2) { greetingResult in
         guard self.isOpen() else { return }
         switch greetingResult {
         case let .failure(error):
@@ -1107,11 +1108,11 @@ private final class UDPFlowBridge: FlowBridge, @unchecked Sendable {
       let request = try Socks5ConnectRequest.udpAssociateBytes()
       controlConnection.send(content: request, completion: .contentProcessed { [weak self] error in
         guard let self else { return }
-        guard self.isOpen() else { return }
+        guard isOpen() else { return }
         if let error {
           completion(.failure(error))
         } else {
-          self.readSocksReply(completion: completion)
+          readSocksReply(completion: completion)
         }
       })
     } catch {
@@ -1123,7 +1124,8 @@ private final class UDPFlowBridge: FlowBridge, @unchecked Sendable {
     guard isOpen() else { return }
     guard let portValue = UInt16(exactly: reply.bindEndpoint.port),
           let relayPort = NWEndpoint.Port(rawValue: portValue),
-          reply.bindEndpoint.port > 0 else {
+          reply.bindEndpoint.port > 0
+    else {
       close(BridgeError.make("SOCKS5 UDP relay returned an invalid port: \(reply.bindEndpoint.port)."))
       return
     }
@@ -1131,14 +1133,14 @@ private final class UDPFlowBridge: FlowBridge, @unchecked Sendable {
     let udpConnection = NWConnection(host: relayHost, port: relayPort, using: .udp)
     udpConnection.stateUpdateHandler = { [weak self] state in
       guard let self else { return }
-      guard self.isOpen() else { return }
+      guard isOpen() else { return }
       switch state {
       case .ready:
-        self.openFlowAndCopy()
+        openFlowAndCopy()
       case let .failed(error):
-        self.close(error)
+        close(error)
       case .cancelled:
-        self.close(nil)
+        close(nil)
       default:
         break
       }
@@ -1168,14 +1170,14 @@ private final class UDPFlowBridge: FlowBridge, @unchecked Sendable {
     guard isOpen() else { return }
     flow.open(withLocalFlowEndpoint: nil) { [weak self] error in
       guard let self else { return }
-      guard self.isOpen() else { return }
+      guard isOpen() else { return }
       if let error {
-        self.close(error)
+        close(error)
         return
       }
       Self.log.info("UDP flow bridge ready; targetPortCategory=\(Self.targetPortCategory(from: self.initialEndpoint), privacy: .public)")
-      self.copyFlowToRelay()
-      self.copyRelayToFlow()
+      copyFlowToRelay()
+      copyRelayToFlow()
     }
   }
 
@@ -1183,20 +1185,20 @@ private final class UDPFlowBridge: FlowBridge, @unchecked Sendable {
     guard isOpen() else { return }
     flow.readDatagrams { [weak self] datagrams, error in
       guard let self else { return }
-      guard self.isOpen() else { return }
+      guard isOpen() else { return }
       if let error {
-        self.close(error)
+        close(error)
         return
       }
       guard let datagrams else {
-        self.close(nil)
+        close(nil)
         return
       }
       guard !datagrams.isEmpty else {
-        self.copyFlowToRelay()
+        copyFlowToRelay()
         return
       }
-      self.sendDatagramsToRelay(datagrams, index: 0)
+      sendDatagramsToRelay(datagrams, index: 0)
     }
   }
 
@@ -1236,11 +1238,11 @@ private final class UDPFlowBridge: FlowBridge, @unchecked Sendable {
 
     udpConnection.send(content: encoded, completion: .contentProcessed { [weak self] error in
       guard let self else { return }
-      guard self.isOpen() else { return }
+      guard isOpen() else { return }
       if let error {
-        self.close(error)
+        close(error)
       } else {
-        self.sendDatagramsToRelay(datagrams, index: index + 1)
+        sendDatagramsToRelay(datagrams, index: index + 1)
       }
     })
   }
@@ -1254,13 +1256,13 @@ private final class UDPFlowBridge: FlowBridge, @unchecked Sendable {
     }
     udpConnection.receiveMessage { [weak self] data, _, _, error in
       guard let self else { return }
-      guard self.isOpen() else { return }
+      guard isOpen() else { return }
       if let error {
-        self.close(error)
+        close(error)
         return
       }
       guard let data, !data.isEmpty else {
-        self.copyRelayToFlow()
+        copyRelayToFlow()
         return
       }
 
@@ -1276,23 +1278,23 @@ private final class UDPFlowBridge: FlowBridge, @unchecked Sendable {
         }
         return
       } catch {
-        self.close(error)
+        close(error)
         return
       }
 
-      let responseEndpoint = self.responseEndpoint(for: decoded.endpoint, payload: decoded.payload)
+      let responseEndpoint = responseEndpoint(for: decoded.endpoint, payload: decoded.payload)
       guard let endpoint = Self.nwEndpoint(from: responseEndpoint) else {
-        self.udpRelayFailed = true
-        self.close(BridgeError.make("SOCKS5 UDP reply has an unsupported source endpoint."))
+        udpRelayFailed = true
+        close(BridgeError.make("SOCKS5 UDP reply has an unsupported source endpoint."))
         return
       }
-      self.flow.writeDatagrams([(decoded.payload, endpoint)]) { [weak self] error in
+      flow.writeDatagrams([(decoded.payload, endpoint)]) { [weak self] error in
         guard let self else { return }
-        guard self.isOpen() else { return }
+        guard isOpen() else { return }
         if let error {
-          self.close(error)
+          close(error)
         } else {
-          self.copyRelayToFlow()
+          copyRelayToFlow()
         }
       }
     }
@@ -1302,7 +1304,7 @@ private final class UDPFlowBridge: FlowBridge, @unchecked Sendable {
     guard isOpen() else { return }
     receiveExact(length: 4) { [weak self] result in
       guard let self else { return }
-      guard self.isOpen() else { return }
+      guard isOpen() else { return }
       switch result {
       case let .failure(error):
         completion(.failure(error))
@@ -1315,7 +1317,7 @@ private final class UDPFlowBridge: FlowBridge, @unchecked Sendable {
           completion(.failure(Socks5ReplyError.failureReply(header[1])))
           return
         }
-        self.readSocksReplyAddress(addressType: header[3]) { addressResult in
+        readSocksReplyAddress(addressType: header[3]) { addressResult in
           switch addressResult {
           case let .failure(error):
             completion(.failure(error))
@@ -1323,7 +1325,7 @@ private final class UDPFlowBridge: FlowBridge, @unchecked Sendable {
             var response = header
             response.append(addressData)
             do {
-              completion(.success(try Socks5ReplyParser.parse(response)))
+              try completion(.success(Socks5ReplyParser.parse(response)))
             } catch {
               completion(.failure(error))
             }
@@ -1343,13 +1345,13 @@ private final class UDPFlowBridge: FlowBridge, @unchecked Sendable {
     case 0x03:
       receiveExact(length: 1) { [weak self] result in
         guard let self else { return }
-        guard self.isOpen() else { return }
+        guard isOpen() else { return }
         switch result {
         case let .failure(error):
           completion(.failure(error))
         case let .success(lengthBytes):
           let length = Int(lengthBytes[0])
-          self.receiveExact(length: length + 2) { result in
+          receiveExact(length: length + 2) { result in
             completion(result.map { remainder in
               var data = lengthBytes
               data.append(remainder)
@@ -1378,7 +1380,7 @@ private final class UDPFlowBridge: FlowBridge, @unchecked Sendable {
     let remaining = length - accumulated.count
     controlConnection.receive(minimumIncompleteLength: 1, maximumLength: remaining) { [weak self] data, _, isComplete, error in
       guard let self else { return }
-      guard self.isOpen() else { return }
+      guard isOpen() else { return }
       if let error {
         completion(.failure(error))
         return
@@ -1392,7 +1394,7 @@ private final class UDPFlowBridge: FlowBridge, @unchecked Sendable {
       } else if isComplete {
         completion(.failure(BridgeError.make("SOCKS5 server closed before sending enough data.")))
       } else {
-        self.receiveExact(length: length, accumulated: next, completion: completion)
+        receiveExact(length: length, accumulated: next, completion: completion)
       }
     }
   }
@@ -1439,7 +1441,8 @@ private final class UDPFlowBridge: FlowBridge, @unchecked Sendable {
   private static func nwEndpoint(from endpoint: Socks5Endpoint) -> NWEndpoint? {
     guard let portValue = UInt16(exactly: endpoint.port),
           let port = NWEndpoint.Port(rawValue: portValue),
-          endpoint.port > 0 else {
+          endpoint.port > 0
+    else {
       return nil
     }
     let host: NWEndpoint.Host
@@ -1548,7 +1551,7 @@ private struct ProxyStartCompletion: @unchecked Sendable {
     self.handler = handler
   }
 
-  func callAsFunction(_ error: ((any Error)?)) {
+  func callAsFunction(_ error: (any Error)?) {
     handler(error)
   }
 }

--- a/ClashMaxTests/AppActivationPolicyTests.swift
+++ b/ClashMaxTests/AppActivationPolicyTests.swift
@@ -1,6 +1,6 @@
 import AppKit
-import XCTest
 @testable import ClashMax
+import XCTest
 
 final class AppActivationPolicyTests: XCTestCase {
   func testLaunchWarmupsAreSuppressedForXCTestEnvironment() {
@@ -43,7 +43,7 @@ final class AppActivationPolicyTests: XCTestCase {
         canBecomeMain: true,
         isVisible: true,
         isMiniaturized: false
-      )
+      ),
     ]
 
     XCTAssertEqual(AppActivationPolicyResolver.policy(for: windows), .regular)
@@ -55,7 +55,7 @@ final class AppActivationPolicyTests: XCTestCase {
         canBecomeMain: true,
         isVisible: true,
         isMiniaturized: false
-      )
+      ),
     ]
 
     XCTAssertEqual(AppActivationPolicyResolver.policy(for: windows), .regular)
@@ -67,7 +67,7 @@ final class AppActivationPolicyTests: XCTestCase {
         canBecomeMain: true,
         isVisible: false,
         isMiniaturized: true
-      )
+      ),
     ]
 
     XCTAssertEqual(AppActivationPolicyResolver.policy(for: windows), .regular)
@@ -80,7 +80,7 @@ final class AppActivationPolicyTests: XCTestCase {
         isVisible: true,
         isMiniaturized: false,
         isPanel: true
-      )
+      ),
     ]
 
     XCTAssertEqual(AppActivationPolicyResolver.policy(for: windows), .accessory)
@@ -92,7 +92,7 @@ final class AppActivationPolicyTests: XCTestCase {
         canBecomeMain: true,
         isVisible: false,
         isMiniaturized: false
-      )
+      ),
     ]
 
     XCTAssertEqual(AppActivationPolicyResolver.policy(for: windows), .accessory)
@@ -105,7 +105,7 @@ final class AppActivationPolicyTests: XCTestCase {
         isVisible: true,
         isMiniaturized: false,
         isPanel: true
-      )
+      ),
     ]
 
     XCTAssertEqual(AppActivationPolicyResolver.policy(for: windows), .accessory)
@@ -142,7 +142,7 @@ final class AppActivationPolicyTests: XCTestCase {
         canBecomeMain: true,
         isVisible: true,
         isMiniaturized: false
-      )
+      ),
     ]
 
     XCTAssertFalse(AppActivationPolicyResolver.shouldOpenMainWindow(for: windows))
@@ -154,7 +154,7 @@ final class AppActivationPolicyTests: XCTestCase {
         canBecomeMain: true,
         isVisible: false,
         isMiniaturized: true
-      )
+      ),
     ]
 
     XCTAssertFalse(AppActivationPolicyResolver.shouldOpenMainWindow(for: windows))
@@ -166,7 +166,7 @@ final class AppActivationPolicyTests: XCTestCase {
         canBecomeMain: true,
         isVisible: false,
         isMiniaturized: false
-      )
+      ),
     ]
 
     XCTAssertFalse(AppActivationPolicyResolver.shouldOpenMainWindow(for: windows))
@@ -179,7 +179,7 @@ final class AppActivationPolicyTests: XCTestCase {
         isVisible: true,
         isMiniaturized: false,
         isPanel: true
-      )
+      ),
     ]
 
     XCTAssertTrue(AppActivationPolicyResolver.shouldOpenMainWindow(for: windows))
@@ -242,7 +242,7 @@ final class AppActivationPolicyTests: XCTestCase {
     let event = Self.launchEvent()
     // 'othr': any launch property that is not the login-item marker.
     event.setParam(
-      NSAppleEventDescriptor(enumCode: OSType(0x6F74_6872)),
+      NSAppleEventDescriptor(enumCode: OSType(0x6f74_6872)),
       forKeyword: OSType(keyAEPropData)
     )
 

--- a/ClashMaxTests/AppUpdateChannelTests.swift
+++ b/ClashMaxTests/AppUpdateChannelTests.swift
@@ -1,6 +1,6 @@
+@testable import ClashMax
 import Foundation
 import XCTest
-@testable import ClashMax
 
 /// Sparkle filters appcast items by minimum system version only. An
 /// Apple-silicon-only build therefore has to be published under a channel that

--- a/ClashMaxTests/BackupRestoreServiceTests.swift
+++ b/ClashMaxTests/BackupRestoreServiceTests.swift
@@ -1,7 +1,7 @@
+@testable import ClashMax
 import Foundation
 import ServiceManagement
 import XCTest
-@testable import ClashMax
 
 @MainActor
 final class BackupRestoreServiceTests: XCTestCase {
@@ -18,7 +18,7 @@ final class BackupRestoreServiceTests: XCTestCase {
       profileStore: sourceStore,
       settings: makeSettings(defaults: source.defaults),
       proxyPreview: ProxyPreviewStore(defaults: source.defaults),
-      runtimeSnippetLibrary: await makeSnippetLibrary(paths: source.paths),
+      runtimeSnippetLibrary: makeSnippetLibrary(paths: source.paths),
       includeSecrets: false,
       password: nil
     )
@@ -54,7 +54,7 @@ final class BackupRestoreServiceTests: XCTestCase {
       profileStore: restoreStore,
       settings: makeSettings(defaults: restore.defaults),
       proxyPreview: ProxyPreviewStore(defaults: restore.defaults),
-      runtimeSnippetLibrary: await makeSnippetLibrary(paths: restore.paths)
+      runtimeSnippetLibrary: makeSnippetLibrary(paths: restore.paths)
     )
 
     XCTAssertEqual(summary.importedProfileCount, 0)
@@ -122,7 +122,7 @@ final class BackupRestoreServiceTests: XCTestCase {
       profileStore: sourceProfileStore,
       settings: makeSettings(defaults: source.defaults),
       proxyPreview: ProxyPreviewStore(defaults: source.defaults),
-      runtimeSnippetLibrary: await makeSnippetLibrary(paths: source.paths),
+      runtimeSnippetLibrary: makeSnippetLibrary(paths: source.paths),
       outboundProxyStore: sourceEndpointStore,
       includeSecrets: false,
       password: nil
@@ -153,7 +153,7 @@ final class BackupRestoreServiceTests: XCTestCase {
       profileStore: restoreProfileStore,
       settings: makeSettings(defaults: restore.defaults),
       proxyPreview: ProxyPreviewStore(defaults: restore.defaults),
-      runtimeSnippetLibrary: await makeSnippetLibrary(paths: restore.paths),
+      runtimeSnippetLibrary: makeSnippetLibrary(paths: restore.paths),
       outboundProxyStore: restoreEndpointStore
     )
 
@@ -189,7 +189,7 @@ final class BackupRestoreServiceTests: XCTestCase {
       profileStore: sourceProfileStore,
       settings: makeSettings(defaults: source.defaults),
       proxyPreview: ProxyPreviewStore(defaults: source.defaults),
-      runtimeSnippetLibrary: await makeSnippetLibrary(paths: source.paths),
+      runtimeSnippetLibrary: makeSnippetLibrary(paths: source.paths),
       outboundProxyStore: sourceEndpointStore,
       includeSecrets: true,
       password: "correct-password"
@@ -216,7 +216,7 @@ final class BackupRestoreServiceTests: XCTestCase {
       profileStore: restoreProfileStore,
       settings: makeSettings(defaults: restore.defaults),
       proxyPreview: ProxyPreviewStore(defaults: restore.defaults),
-      runtimeSnippetLibrary: await makeSnippetLibrary(paths: restore.paths),
+      runtimeSnippetLibrary: makeSnippetLibrary(paths: restore.paths),
       outboundProxyStore: restoreEndpointStore
     )
 
@@ -242,7 +242,7 @@ final class BackupRestoreServiceTests: XCTestCase {
       profileStore: skippedProfileStore,
       settings: makeSettings(defaults: skippedRestore.defaults),
       proxyPreview: ProxyPreviewStore(defaults: skippedRestore.defaults),
-      runtimeSnippetLibrary: await makeSnippetLibrary(paths: skippedRestore.paths),
+      runtimeSnippetLibrary: makeSnippetLibrary(paths: skippedRestore.paths),
       outboundProxyStore: skippedEndpointStore
     )
     let skippedResolved = try await skippedEndpointStore.resolve(id: endpoint.id)
@@ -296,7 +296,7 @@ final class BackupRestoreServiceTests: XCTestCase {
       profileStore: sourceProfileStore,
       settings: makeSettings(defaults: source.defaults),
       proxyPreview: ProxyPreviewStore(defaults: source.defaults),
-      runtimeSnippetLibrary: await makeSnippetLibrary(paths: source.paths),
+      runtimeSnippetLibrary: makeSnippetLibrary(paths: source.paths),
       outboundProxyStore: sourceEndpointStore,
       includeSecrets: false,
       password: nil
@@ -354,7 +354,7 @@ final class BackupRestoreServiceTests: XCTestCase {
       profileStore: restoreProfileStore,
       settings: makeSettings(defaults: restore.defaults),
       proxyPreview: ProxyPreviewStore(defaults: restore.defaults),
-      runtimeSnippetLibrary: await makeSnippetLibrary(paths: restore.paths),
+      runtimeSnippetLibrary: makeSnippetLibrary(paths: restore.paths),
       outboundProxyStore: restoreEndpointStore
     )
 
@@ -423,7 +423,7 @@ final class BackupRestoreServiceTests: XCTestCase {
       profileStore: sourceProfileStore,
       settings: makeSettings(defaults: source.defaults),
       proxyPreview: ProxyPreviewStore(defaults: source.defaults),
-      runtimeSnippetLibrary: await makeSnippetLibrary(paths: source.paths),
+      runtimeSnippetLibrary: makeSnippetLibrary(paths: source.paths),
       outboundProxyStore: sourceEndpointStore,
       includeSecrets: false,
       password: nil
@@ -455,7 +455,7 @@ final class BackupRestoreServiceTests: XCTestCase {
       profileStore: restoreProfileStore,
       settings: makeSettings(defaults: restore.defaults),
       proxyPreview: ProxyPreviewStore(defaults: restore.defaults),
-      runtimeSnippetLibrary: await makeSnippetLibrary(paths: restore.paths),
+      runtimeSnippetLibrary: makeSnippetLibrary(paths: restore.paths),
       outboundProxyStore: restoreEndpointStore
     )
 
@@ -483,7 +483,7 @@ final class BackupRestoreServiceTests: XCTestCase {
             kind: .http,
             host: "invalid.example",
             port: 0
-          )
+          ),
         ]
       ),
       (
@@ -502,7 +502,7 @@ final class BackupRestoreServiceTests: XCTestCase {
             kind: .socks5,
             host: "second.example",
             port: 1080
-          )
+          ),
         ]
       ),
       (
@@ -519,9 +519,9 @@ final class BackupRestoreServiceTests: XCTestCase {
             kind: .socks5,
             host: "two.example",
             port: 1080
-          )
+          ),
         ]
-      )
+      ),
     ]
 
     for (name, endpoints) in cases {
@@ -580,7 +580,7 @@ final class BackupRestoreServiceTests: XCTestCase {
       profileStore: sourceProfileStore,
       settings: makeSettings(defaults: source.defaults),
       proxyPreview: ProxyPreviewStore(defaults: source.defaults),
-      runtimeSnippetLibrary: await makeSnippetLibrary(paths: source.paths),
+      runtimeSnippetLibrary: makeSnippetLibrary(paths: source.paths),
       outboundProxyStore: sourceEndpointStore,
       includeSecrets: true,
       password: "correct-password"
@@ -611,7 +611,7 @@ final class BackupRestoreServiceTests: XCTestCase {
       profileStore: store,
       settings: settings,
       proxyPreview: preview,
-      runtimeSnippetLibrary: await makeSnippetLibrary(paths: fixture.paths),
+      runtimeSnippetLibrary: makeSnippetLibrary(paths: fixture.paths),
       includeSecrets: false,
       password: nil
     )
@@ -637,7 +637,7 @@ final class BackupRestoreServiceTests: XCTestCase {
       profileStore: sourceStore,
       settings: sourceSettings,
       proxyPreview: sourcePreview,
-      runtimeSnippetLibrary: await makeSnippetLibrary(paths: source.paths),
+      runtimeSnippetLibrary: makeSnippetLibrary(paths: source.paths),
       includeSecrets: true,
       password: "correct-password"
     )
@@ -658,7 +658,7 @@ final class BackupRestoreServiceTests: XCTestCase {
         profileStore: wrongPasswordStore,
         settings: makeSettings(defaults: wrongPasswordFixture.defaults),
         proxyPreview: ProxyPreviewStore(defaults: wrongPasswordFixture.defaults),
-        runtimeSnippetLibrary: await makeSnippetLibrary(paths: wrongPasswordFixture.paths)
+        runtimeSnippetLibrary: makeSnippetLibrary(paths: wrongPasswordFixture.paths)
       )
     } handler: { error in
       XCTAssertEqual(error as? BackupRestoreError, .invalidPassword)
@@ -674,7 +674,7 @@ final class BackupRestoreServiceTests: XCTestCase {
       profileStore: restoreStore,
       settings: makeSettings(defaults: restore.defaults),
       proxyPreview: ProxyPreviewStore(defaults: restore.defaults),
-      runtimeSnippetLibrary: await makeSnippetLibrary(paths: restore.paths)
+      runtimeSnippetLibrary: makeSnippetLibrary(paths: restore.paths)
     )
 
     let restoredProfile = try XCTUnwrap(restoreStore.profiles.first)
@@ -696,7 +696,7 @@ final class BackupRestoreServiceTests: XCTestCase {
       profileStore: sourceStore,
       settings: makeSettings(defaults: source.defaults),
       proxyPreview: ProxyPreviewStore(defaults: source.defaults),
-      runtimeSnippetLibrary: await makeSnippetLibrary(paths: source.paths),
+      runtimeSnippetLibrary: makeSnippetLibrary(paths: source.paths),
       includeSecrets: true,
       password: "correct-password"
     )
@@ -721,7 +721,7 @@ final class BackupRestoreServiceTests: XCTestCase {
       profileStore: restoreStore,
       settings: makeSettings(defaults: restore.defaults),
       proxyPreview: ProxyPreviewStore(defaults: restore.defaults),
-      runtimeSnippetLibrary: await makeSnippetLibrary(paths: restore.paths)
+      runtimeSnippetLibrary: makeSnippetLibrary(paths: restore.paths)
     )
 
     let restoredProfile = try XCTUnwrap(restoreStore.profiles.first)
@@ -743,7 +743,7 @@ final class BackupRestoreServiceTests: XCTestCase {
       profileStore: sourceStore,
       settings: makeSettings(defaults: source.defaults),
       proxyPreview: ProxyPreviewStore(defaults: source.defaults),
-      runtimeSnippetLibrary: await makeSnippetLibrary(paths: source.paths),
+      runtimeSnippetLibrary: makeSnippetLibrary(paths: source.paths),
       includeSecrets: false,
       password: nil
     )
@@ -768,7 +768,7 @@ final class BackupRestoreServiceTests: XCTestCase {
       profileStore: restoreStore,
       settings: makeSettings(defaults: restore.defaults),
       proxyPreview: ProxyPreviewStore(defaults: restore.defaults),
-      runtimeSnippetLibrary: await makeSnippetLibrary(paths: restore.paths)
+      runtimeSnippetLibrary: makeSnippetLibrary(paths: restore.paths)
     )
 
     let restoredProfile = try XCTUnwrap(restoreStore.profiles.first)
@@ -791,7 +791,7 @@ final class BackupRestoreServiceTests: XCTestCase {
       profileStore: sourceStore,
       settings: makeSettings(defaults: source.defaults),
       proxyPreview: ProxyPreviewStore(defaults: source.defaults),
-      runtimeSnippetLibrary: await makeSnippetLibrary(paths: source.paths),
+      runtimeSnippetLibrary: makeSnippetLibrary(paths: source.paths),
       includeSecrets: true,
       password: "correct-password"
     )
@@ -805,7 +805,7 @@ final class BackupRestoreServiceTests: XCTestCase {
       profileStore: restoreStore,
       settings: makeSettings(defaults: restore.defaults),
       proxyPreview: ProxyPreviewStore(defaults: restore.defaults),
-      runtimeSnippetLibrary: await makeSnippetLibrary(paths: restore.paths)
+      runtimeSnippetLibrary: makeSnippetLibrary(paths: restore.paths)
     )
 
     let restoredProfile = try XCTUnwrap(restoreStore.profiles.first)
@@ -826,7 +826,7 @@ final class BackupRestoreServiceTests: XCTestCase {
       profileStore: sourceStore,
       settings: makeSettings(defaults: source.defaults),
       proxyPreview: ProxyPreviewStore(defaults: source.defaults),
-      runtimeSnippetLibrary: await makeSnippetLibrary(paths: source.paths),
+      runtimeSnippetLibrary: makeSnippetLibrary(paths: source.paths),
       includeSecrets: true,
       password: "correct-password"
     )
@@ -847,7 +847,7 @@ final class BackupRestoreServiceTests: XCTestCase {
         profileStore: restoreStore,
         settings: makeSettings(defaults: restore.defaults),
         proxyPreview: ProxyPreviewStore(defaults: restore.defaults),
-        runtimeSnippetLibrary: await makeSnippetLibrary(paths: restore.paths)
+        runtimeSnippetLibrary: makeSnippetLibrary(paths: restore.paths)
       )
     } handler: { error in
       XCTAssertEqual(error as? BackupRestoreError, .invalidPassword)
@@ -868,7 +868,7 @@ final class BackupRestoreServiceTests: XCTestCase {
       profileStore: store,
       settings: makeSettings(defaults: fixture.defaults),
       proxyPreview: preview,
-      runtimeSnippetLibrary: await makeSnippetLibrary(paths: fixture.paths),
+      runtimeSnippetLibrary: makeSnippetLibrary(paths: fixture.paths),
       includeSecrets: false,
       password: nil
     )
@@ -878,7 +878,7 @@ final class BackupRestoreServiceTests: XCTestCase {
       profileStore: store,
       settings: makeSettings(defaults: fixture.defaults),
       proxyPreview: preview,
-      runtimeSnippetLibrary: await makeSnippetLibrary(paths: fixture.paths)
+      runtimeSnippetLibrary: makeSnippetLibrary(paths: fixture.paths)
     )
 
     XCTAssertEqual(summary.importedProfileCount, 1)
@@ -911,7 +911,7 @@ final class BackupRestoreServiceTests: XCTestCase {
       profileStore: sourceStore,
       settings: sourceSettings,
       proxyPreview: ProxyPreviewStore(defaults: source.defaults),
-      runtimeSnippetLibrary: await makeSnippetLibrary(paths: source.paths),
+      runtimeSnippetLibrary: makeSnippetLibrary(paths: source.paths),
       includeSecrets: false,
       password: nil
     )
@@ -937,7 +937,7 @@ final class BackupRestoreServiceTests: XCTestCase {
       profileStore: restoreStore,
       settings: restoreSettings,
       proxyPreview: ProxyPreviewStore(defaults: restore.defaults),
-      runtimeSnippetLibrary: await makeSnippetLibrary(paths: restore.paths)
+      runtimeSnippetLibrary: makeSnippetLibrary(paths: restore.paths)
     )
 
     XCTAssertEqual(restoreSettings.overrides.mixedPort, 17_777)
@@ -958,7 +958,7 @@ final class BackupRestoreServiceTests: XCTestCase {
       profileStore: sourceStore,
       settings: makeSettings(defaults: source.defaults),
       proxyPreview: ProxyPreviewStore(defaults: source.defaults),
-      runtimeSnippetLibrary: await makeSnippetLibrary(paths: source.paths),
+      runtimeSnippetLibrary: makeSnippetLibrary(paths: source.paths),
       includeSecrets: true,
       password: "correct-password"
     )
@@ -972,7 +972,7 @@ final class BackupRestoreServiceTests: XCTestCase {
       profileStore: restoreStore,
       settings: makeSettings(defaults: restore.defaults),
       proxyPreview: ProxyPreviewStore(defaults: restore.defaults),
-      runtimeSnippetLibrary: await makeSnippetLibrary(paths: restore.paths)
+      runtimeSnippetLibrary: makeSnippetLibrary(paths: restore.paths)
     )
 
     let restoredProfile = try XCTUnwrap(restoreStore.profiles.first)
@@ -1002,7 +1002,7 @@ final class BackupRestoreServiceTests: XCTestCase {
       }),
       ("short-payload", { secrets in
         secrets.sealedPayload = Data(repeating: 0, count: 27)
-      })
+      }),
     ]
 
     for (name, mutate) in malformedBackups {
@@ -1027,7 +1027,7 @@ final class BackupRestoreServiceTests: XCTestCase {
           profileStore: restoreStore,
           settings: makeSettings(defaults: restore.defaults),
           proxyPreview: ProxyPreviewStore(defaults: restore.defaults),
-          runtimeSnippetLibrary: await makeSnippetLibrary(paths: restore.paths)
+          runtimeSnippetLibrary: makeSnippetLibrary(paths: restore.paths)
         )
       } handler: { error in
         self.assertInvalidBackup(error)
@@ -1041,7 +1041,7 @@ final class BackupRestoreServiceTests: XCTestCase {
     let manifestProfile = try XCTUnwrap(backup.profilesManifest.profiles.first)
     let manifestIndex = try XCTUnwrap(backup.profilesManifest.profiles.firstIndex(where: { $0.id == manifestProfile.id }))
     backup.profilesManifest.profiles[manifestIndex].subscriptionProviderOptions.requestHeaders = [
-      SubscriptionRequestHeader(id: UUID(), name: "Authorization", value: "")
+      SubscriptionRequestHeader(id: UUID(), name: "Authorization", value: ""),
     ]
     let malformedURL = source.root.appendingPathComponent("unknown-encrypted-header.clashmax-backup")
     try writeBackup(backup, to: malformedURL)
@@ -1062,7 +1062,7 @@ final class BackupRestoreServiceTests: XCTestCase {
         profileStore: restoreStore,
         settings: settings,
         proxyPreview: ProxyPreviewStore(defaults: restore.defaults),
-        runtimeSnippetLibrary: await makeSnippetLibrary(paths: restore.paths)
+        runtimeSnippetLibrary: makeSnippetLibrary(paths: restore.paths)
       )
     } handler: { error in
       self.assertInvalidBackup(error)
@@ -1077,7 +1077,7 @@ final class BackupRestoreServiceTests: XCTestCase {
   func testPreviewRejectsDuplicateManifestProfileIDs() async throws {
     let fixture = try BackupFixture()
     var backup = try await exportLocalBackup(in: fixture)
-    backup.profilesManifest.profiles.append(try XCTUnwrap(backup.profilesManifest.profiles.first))
+    try backup.profilesManifest.profiles.append(XCTUnwrap(backup.profilesManifest.profiles.first))
     let malformedURL = fixture.root.appendingPathComponent("duplicate-manifest.clashmax-backup")
     try writeBackup(backup, to: malformedURL)
 
@@ -1089,7 +1089,7 @@ final class BackupRestoreServiceTests: XCTestCase {
   func testPreviewRejectsDuplicateProfileSourceIDs() async throws {
     let fixture = try BackupFixture()
     var backup = try await exportLocalBackup(in: fixture)
-    backup.profileSources.append(try XCTUnwrap(backup.profileSources.first))
+    try backup.profileSources.append(XCTUnwrap(backup.profileSources.first))
     let malformedURL = fixture.root.appendingPathComponent("duplicate-sources.clashmax-backup")
     try writeBackup(backup, to: malformedURL)
 
@@ -1143,7 +1143,7 @@ final class BackupRestoreServiceTests: XCTestCase {
       id: profileID,
       source: .subscription(id: profileID),
       requestHeaders: [
-        SubscriptionRequestHeader(id: headerID, name: "Authorization", value: "")
+        SubscriptionRequestHeader(id: headerID, name: "Authorization", value: ""),
       ]
     )
     let source = BackupProfileSource(
@@ -1158,10 +1158,10 @@ final class BackupRestoreServiceTests: XCTestCase {
           subscriptionURL: nil,
           requestHeaders: [
             BackupRequestHeaderSecret(headerID: headerID, value: "Bearer one"),
-            BackupRequestHeaderSecret(headerID: headerID, value: "Bearer two")
+            BackupRequestHeaderSecret(headerID: headerID, value: "Bearer two"),
           ],
           runtimeMergeYAML: nil
-        )
+        ),
       ]
     )
 
@@ -1188,7 +1188,7 @@ final class BackupRestoreServiceTests: XCTestCase {
       id: profileID,
       source: .subscription(id: profileID),
       requestHeaders: [
-        SubscriptionRequestHeader(id: headerID, name: "Authorization", value: "")
+        SubscriptionRequestHeader(id: headerID, name: "Authorization", value: ""),
       ]
     )
     let source = BackupProfileSource(
@@ -1202,10 +1202,10 @@ final class BackupRestoreServiceTests: XCTestCase {
           profileID: profileID,
           subscriptionURL: nil,
           requestHeaders: [
-            BackupRequestHeaderSecret(headerID: unknownHeaderID, value: "Bearer hidden")
+            BackupRequestHeaderSecret(headerID: unknownHeaderID, value: "Bearer hidden"),
           ],
           runtimeMergeYAML: nil
-        )
+        ),
       ]
     )
 
@@ -1234,7 +1234,7 @@ final class BackupRestoreServiceTests: XCTestCase {
         RuleOverlaySettings(
           enabled: true,
           prependRules: [
-            ManagedRuleOverlayRule(kind: .domainSuffix, value: "snippet.example", policy: "DIRECT")
+            ManagedRuleOverlayRule(kind: .domainSuffix, value: "snippet.example", policy: "DIRECT"),
           ]
         )
       )
@@ -1363,11 +1363,11 @@ final class BackupRestoreServiceTests: XCTestCase {
           RuleOverlaySettings(
             enabled: true,
             prependRules: [
-              ManagedRuleOverlayRule(kind: .domainSuffix, value: "bad.example", policy: "DIRECT")
+              ManagedRuleOverlayRule(kind: .domainSuffix, value: "bad.example", policy: "DIRECT"),
             ]
           )
         )
-      )
+      ),
     ]
     let backupURL = source.root.appendingPathComponent("invalid-snippet.clashmax-backup")
     try writeBackup(backup, to: backupURL)
@@ -1818,7 +1818,7 @@ final class BackupRestoreServiceTests: XCTestCase {
       requestHeaders: [header]
     )
     try await store.updateSubscriptionProviderOptions(profile, options: options)
-    return (store, try XCTUnwrap(store.profiles.first))
+    return try (store, XCTUnwrap(store.profiles.first))
   }
 
   private func exportLocalBackup(in fixture: BackupFixture) async throws -> ClashMaxBackupFile {
@@ -1830,7 +1830,7 @@ final class BackupRestoreServiceTests: XCTestCase {
       profileStore: store,
       settings: makeSettings(defaults: fixture.defaults),
       proxyPreview: ProxyPreviewStore(defaults: fixture.defaults),
-      runtimeSnippetLibrary: await makeSnippetLibrary(paths: fixture.paths),
+      runtimeSnippetLibrary: makeSnippetLibrary(paths: fixture.paths),
       includeSecrets: false,
       password: nil
     )
@@ -1849,7 +1849,7 @@ final class BackupRestoreServiceTests: XCTestCase {
       profileStore: store,
       settings: makeSettings(defaults: fixture.defaults),
       proxyPreview: ProxyPreviewStore(defaults: fixture.defaults),
-      runtimeSnippetLibrary: await makeSnippetLibrary(paths: fixture.paths),
+      runtimeSnippetLibrary: makeSnippetLibrary(paths: fixture.paths),
       includeSecrets: true,
       password: password
     )
@@ -2029,7 +2029,8 @@ private actor FailOnceAfterStoringRuntimeSnippetLibraryDiskIO: RuntimeSnippetLib
 }
 
 private actor FailOnSecondOutboundProxyEndpointManifestSave:
-  OutboundProxyEndpointManifestStoring {
+  OutboundProxyEndpointManifestStoring
+{
   private let base = OutboundProxyEndpointDiskIO()
   private var saveCount = 0
 

--- a/ClashMaxTests/BundledCoreInfoTests.swift
+++ b/ClashMaxTests/BundledCoreInfoTests.swift
@@ -1,6 +1,6 @@
+@testable import ClashMax
 import Foundation
 import XCTest
-@testable import ClashMax
 
 final class BundledCoreInfoTests: XCTestCase {
   func testReadsBundledCoreVersionFromManifest() throws {

--- a/ClashMaxTests/ClashXMigrationParserTests.swift
+++ b/ClashMaxTests/ClashXMigrationParserTests.swift
@@ -1,6 +1,6 @@
-import XCTest
-import SQLite3
 @testable import ClashMax
+import SQLite3
+import XCTest
 
 final class ClashXMigrationParserTests: XCTestCase {
   func testParserExtractsProviderURLsDuplicatesPortsBypassSystemProxyAndUnsupportedKeys() throws {
@@ -52,7 +52,7 @@ final class ClashXMigrationParserTests: XCTestCase {
       [
         "https://example.com/sub.yaml",
         "https://mirror.example.com/sub.yaml",
-        "https://airport.example.com/api"
+        "https://airport.example.com/api",
       ]
     )
     XCTAssertEqual(report.duplicateSubscriptionURLs, ["https://example.com/sub.yaml"])
@@ -70,7 +70,7 @@ final class ClashXMigrationParserTests: XCTestCase {
         // identity is "<carbon modifier mask>-<carbon key code>": ⇧⌘R, ⇧⌘P, ⌃⌥S.
         "restartCore:restart:768-15",
         "toggleProxy:startStop:768-35",
-        "systemProxy:toggleSystemProxy:6144-1"
+        "systemProxy:toggleSystemProxy:6144-1",
       ]
     )
     XCTAssertTrue(report.warnings.contains { $0.contains("unknownAction") })

--- a/ClashMaxTests/ConfigNormalizerTests.swift
+++ b/ClashMaxTests/ConfigNormalizerTests.swift
@@ -1,6 +1,6 @@
+@testable import ClashMax
 import XCTest
 import Yams
-@testable import ClashMax
 
 final class ConfigNormalizerTests: XCTestCase {
   func testManualSocksEndpointBuildsRuntimeConfigWithoutReadingSource() throws {
@@ -55,7 +55,7 @@ final class ConfigNormalizerTests: XCTestCase {
         "IP-CIDR6,::1/128,DIRECT,no-resolve",
         "IP-CIDR6,fc00::/7,DIRECT,no-resolve",
         "IP-CIDR6,fe80::/10,DIRECT,no-resolve",
-        "MATCH,Proxy"
+        "MATCH,Proxy",
       ]
     )
   }
@@ -248,7 +248,7 @@ final class ConfigNormalizerTests: XCTestCase {
           proxies: [Node]
       rules:
         - MATCH,Proxy
-      """
+      """,
     ]
 
     for source in conflictingSources {
@@ -411,7 +411,7 @@ final class ConfigNormalizerTests: XCTestCase {
             kind: .domainSuffix,
             value: "managed.example",
             policy: "DIRECT"
-          )
+          ),
         ]
       )
 
@@ -1157,7 +1157,7 @@ final class ConfigNormalizerTests: XCTestCase {
       allowPrivateNetwork: true,
       allowedOrigins: [
         "https://custom.example",
-        "https://yacd.metacubex.one"
+        "https://yacd.metacubex.one",
       ]
     )
 
@@ -1174,7 +1174,7 @@ final class ConfigNormalizerTests: XCTestCase {
         "http://tauri.localhost",
         "http://localhost:3000",
         "https://custom.example",
-        "https://yacd.metacubex.one"
+        "https://yacd.metacubex.one",
       ]
     )
   }
@@ -1402,7 +1402,7 @@ final class ConfigNormalizerTests: XCTestCase {
       root.appendingPathComponent("profile.runtime.not-a-uuid.yaml"),
       root.appendingPathComponent("profile.provider.not-a-uuid.txt"),
       root.appendingPathComponent(".profile.runtime.\(UUID().uuidString).yaml.tmp"),
-      root.appendingPathComponent("other-profile.runtime.\(UUID().uuidString).yaml")
+      root.appendingPathComponent("other-profile.runtime.\(UUID().uuidString).yaml"),
     ]
     for url in unmanagedURLs {
       try "unmanaged".write(to: url, atomically: true, encoding: .utf8)
@@ -1485,7 +1485,7 @@ final class ConfigNormalizerTests: XCTestCase {
         ruleOverlay: RuleOverlaySettings(
           enabled: true,
           appendRules: [
-            ManagedRuleOverlayRule(kind: .domainSuffix, value: "profile.example", policy: "DIRECT")
+            ManagedRuleOverlayRule(kind: .domainSuffix, value: "profile.example", policy: "DIRECT"),
           ]
         )
       )
@@ -1494,7 +1494,7 @@ final class ConfigNormalizerTests: XCTestCase {
     overrides.ruleOverlay = RuleOverlaySettings(
       enabled: true,
       prependRules: [
-        ManagedRuleOverlayRule(kind: .domainSuffix, value: "global.example", policy: "DIRECT")
+        ManagedRuleOverlayRule(kind: .domainSuffix, value: "global.example", policy: "DIRECT"),
       ]
     )
     let snippet = RuntimeSnippet(
@@ -1505,7 +1505,7 @@ final class ConfigNormalizerTests: XCTestCase {
         RuleOverlaySettings(
           enabled: true,
           appendRules: [
-            ManagedRuleOverlayRule(kind: .domainSuffix, value: "snippet.example", policy: "DIRECT")
+            ManagedRuleOverlayRule(kind: .domainSuffix, value: "snippet.example", policy: "DIRECT"),
           ]
         )
       )
@@ -1529,7 +1529,7 @@ final class ConfigNormalizerTests: XCTestCase {
       "Manual Proxy",
       "Upstream Proxy",
       "DNS override",
-      "Final runtime YAML"
+      "Final runtime YAML",
     ])
     XCTAssertEqual(snapshot.preflightStatus, .notRun)
     let exported = snapshot.redactedReportText
@@ -1816,8 +1816,7 @@ final class ConfigNormalizerTests: XCTestCase {
           proxies: [DIRECT]
       rules:
         - MATCH,DIRECT
-      """
-      ),
+      """),
       .clashConfig
     )
     XCTAssertEqual(
@@ -1860,7 +1859,7 @@ final class ConfigNormalizerTests: XCTestCase {
         "GEOIP,private,DIRECT,no-resolve",
         "GEOSITE,cn,DIRECT",
         "GEOIP,CN,DIRECT,no-resolve",
-        "MATCH,Proxy"
+        "MATCH,Proxy",
       ]
     )
   }
@@ -2020,10 +2019,10 @@ final class ConfigNormalizerTests: XCTestCase {
     overrides.ruleOverlay = RuleOverlaySettings(
       enabled: true,
       prependRules: [
-        ManagedRuleOverlayRule(kind: .domainSuffix, value: "corp.example", policy: "DIRECT")
+        ManagedRuleOverlayRule(kind: .domainSuffix, value: "corp.example", policy: "DIRECT"),
       ],
       appendRules: [
-        ManagedRuleOverlayRule(kind: .match, policy: "Proxy")
+        ManagedRuleOverlayRule(kind: .match, policy: "Proxy"),
       ]
     )
 
@@ -2036,7 +2035,7 @@ final class ConfigNormalizerTests: XCTestCase {
         "DOMAIN-SUFFIX,corp.example,DIRECT",
         "DOMAIN-SUFFIX,example.org,Proxy",
         "MATCH,DIRECT",
-        "MATCH,Proxy"
+        "MATCH,Proxy",
       ]
     )
     XCTAssertTrue(source.contains("DOMAIN-SUFFIX,example.org,Proxy"))
@@ -2067,7 +2066,7 @@ final class ConfigNormalizerTests: XCTestCase {
         ManagedRuleOverlayRule(kind: .srcIPSuffix, value: "192.168.1.1/24", policy: "DIRECT"),
         ManagedRuleOverlayRule(kind: .dstPort, value: "443", policy: "Proxy"),
         ManagedRuleOverlayRule(kind: .srcPort, value: "50000-50100", policy: "DIRECT"),
-        ManagedRuleOverlayRule(kind: .inPort, value: "7890", policy: "Proxy")
+        ManagedRuleOverlayRule(kind: .inPort, value: "7890", policy: "Proxy"),
       ]
     )
 
@@ -2086,7 +2085,7 @@ final class ConfigNormalizerTests: XCTestCase {
         "DST-PORT,443,Proxy",
         "SRC-PORT,50000-50100,DIRECT",
         "IN-PORT,7890,Proxy",
-        "MATCH,DIRECT"
+        "MATCH,DIRECT",
       ]
     )
     XCTAssertFalse(source.contains("RemoteRules"))
@@ -2097,7 +2096,7 @@ final class ConfigNormalizerTests: XCTestCase {
     invalidCIDR.ruleOverlay = RuleOverlaySettings(
       enabled: true,
       prependRules: [
-        ManagedRuleOverlayRule(kind: .srcIPCIDR, value: "192.168.1.1", policy: "DIRECT")
+        ManagedRuleOverlayRule(kind: .srcIPCIDR, value: "192.168.1.1", policy: "DIRECT"),
       ]
     )
     XCTAssertThrowsError(
@@ -2113,7 +2112,7 @@ final class ConfigNormalizerTests: XCTestCase {
     invalidPort.ruleOverlay = RuleOverlaySettings(
       enabled: true,
       prependRules: [
-        ManagedRuleOverlayRule(kind: .dstPort, value: "70000", policy: "Proxy")
+        ManagedRuleOverlayRule(kind: .dstPort, value: "70000", policy: "Proxy"),
       ]
     )
     XCTAssertThrowsError(
@@ -2132,7 +2131,7 @@ final class ConfigNormalizerTests: XCTestCase {
     invalidSubRule.ruleOverlay = RuleOverlaySettings(
       enabled: true,
       prependRules: [
-        ManagedRuleOverlayRule(kind: .subRule, value: "DOMAIN,example.com", policy: "sub")
+        ManagedRuleOverlayRule(kind: .subRule, value: "DOMAIN,example.com", policy: "sub"),
       ]
     )
     XCTAssertThrowsError(
@@ -2164,15 +2163,15 @@ final class ConfigNormalizerTests: XCTestCase {
     overrides.ruleOverlay = RuleOverlaySettings(
       enabled: true,
       prependRules: [
-        ManagedRuleOverlayRule(kind: .domainSuffix, value: "trusted.example", policy: "DIRECT")
+        ManagedRuleOverlayRule(kind: .domainSuffix, value: "trusted.example", policy: "DIRECT"),
       ],
       appendRules: [
-        ManagedRuleOverlayRule(kind: .match, policy: "Proxy")
+        ManagedRuleOverlayRule(kind: .match, policy: "Proxy"),
       ],
       disabledRuleMatchers: [
         ManagedRuleDisableMatcher(mode: .contains, pattern: "ads.example"),
         ManagedRuleDisableMatcher(mode: .exact, pattern: "MATCH,DIRECT"),
-        ManagedRuleDisableMatcher(mode: .regex, pattern: #"IP-CIDR,10\."#)
+        ManagedRuleDisableMatcher(mode: .regex, pattern: #"IP-CIDR,10\."#),
       ]
     )
 
@@ -2184,7 +2183,7 @@ final class ConfigNormalizerTests: XCTestCase {
       [
         "DOMAIN-SUFFIX,trusted.example,DIRECT",
         "DOMAIN-SUFFIX,corp.example,Proxy",
-        "MATCH,Proxy"
+        "MATCH,Proxy",
       ]
     )
     XCTAssertTrue(source.contains("DOMAIN-SUFFIX,ads.example,REJECT"))
@@ -2208,13 +2207,13 @@ final class ConfigNormalizerTests: XCTestCase {
     overrides.ruleOverlay = RuleOverlaySettings(
       enabled: true,
       prependRules: [
-        ManagedRuleOverlayRule(kind: .domainSuffix, value: "global.example", policy: "DIRECT")
+        ManagedRuleOverlayRule(kind: .domainSuffix, value: "global.example", policy: "DIRECT"),
       ],
       appendRules: [
-        ManagedRuleOverlayRule(kind: .domainSuffix, value: "global-after.example", policy: "Proxy")
+        ManagedRuleOverlayRule(kind: .domainSuffix, value: "global-after.example", policy: "Proxy"),
       ],
       disabledRuleMatchers: [
-        ManagedRuleDisableMatcher(mode: .contains, pattern: "ads.example")
+        ManagedRuleDisableMatcher(mode: .contains, pattern: "ads.example"),
       ]
     )
     var options = RuntimeConfigOptions.default
@@ -2222,13 +2221,13 @@ final class ConfigNormalizerTests: XCTestCase {
       ruleOverlay: RuleOverlaySettings(
         enabled: true,
         prependRules: [
-          ManagedRuleOverlayRule(kind: .domainSuffix, value: "profile.example", policy: "DIRECT")
+          ManagedRuleOverlayRule(kind: .domainSuffix, value: "profile.example", policy: "DIRECT"),
         ],
         appendRules: [
-          ManagedRuleOverlayRule(kind: .match, policy: "Proxy")
+          ManagedRuleOverlayRule(kind: .match, policy: "Proxy"),
         ],
         disabledRuleMatchers: [
-          ManagedRuleDisableMatcher(mode: .exact, pattern: "MATCH,DIRECT")
+          ManagedRuleDisableMatcher(mode: .exact, pattern: "MATCH,DIRECT"),
         ]
       )
     )
@@ -2243,7 +2242,7 @@ final class ConfigNormalizerTests: XCTestCase {
         "DOMAIN-SUFFIX,profile.example,DIRECT",
         "DOMAIN-SUFFIX,corp.example,Proxy",
         "MATCH,Proxy",
-        "DOMAIN-SUFFIX,global-after.example,Proxy"
+        "DOMAIN-SUFFIX,global-after.example,Proxy",
       ]
     )
   }
@@ -2273,7 +2272,7 @@ final class ConfigNormalizerTests: XCTestCase {
           RuleOverlaySettings(
             enabled: true,
             prependRules: [
-              ManagedRuleOverlayRule(kind: .domainSuffix, value: "disabled.example", policy: "DIRECT")
+              ManagedRuleOverlayRule(kind: .domainSuffix, value: "disabled.example", policy: "DIRECT"),
             ]
           )
         )
@@ -2293,13 +2292,13 @@ final class ConfigNormalizerTests: XCTestCase {
           RuleOverlaySettings(
             enabled: true,
             prependRules: [
-              ManagedRuleOverlayRule(kind: .domainSuffix, value: "a.example", policy: "DIRECT")
+              ManagedRuleOverlayRule(kind: .domainSuffix, value: "a.example", policy: "DIRECT"),
             ],
             appendRules: [
-              ManagedRuleOverlayRule(kind: .match, policy: "Proxy")
+              ManagedRuleOverlayRule(kind: .match, policy: "Proxy"),
             ],
             disabledRuleMatchers: [
-              ManagedRuleDisableMatcher(mode: .contains, pattern: "ads.example")
+              ManagedRuleDisableMatcher(mode: .contains, pattern: "ads.example"),
             ]
           )
         )
@@ -2310,11 +2309,11 @@ final class ConfigNormalizerTests: XCTestCase {
           RuleOverlaySettings(
             enabled: true,
             prependRules: [
-              ManagedRuleOverlayRule(kind: .domainSuffix, value: "b.example", policy: "Proxy")
+              ManagedRuleOverlayRule(kind: .domainSuffix, value: "b.example", policy: "Proxy"),
             ]
           )
         )
-      )
+      ),
     ]
 
     let output = try ConfigNormalizer().runtimeConfig(
@@ -2331,7 +2330,7 @@ final class ConfigNormalizerTests: XCTestCase {
         "DOMAIN-SUFFIX,a.example,DIRECT",
         "DOMAIN-SUFFIX,b.example,Proxy",
         "MATCH,DIRECT",
-        "MATCH,Proxy"
+        "MATCH,Proxy",
       ]
     )
     XCTAssertEqual(dns["nameserver"] as? [String], ["https://existing.example/dns-query", "https://dns.example/dns-query"])
@@ -2378,7 +2377,7 @@ final class ConfigNormalizerTests: XCTestCase {
             proxyServerNameserver: ["https://doh.pub/dns-query"]
           )
         )
-      )
+      ),
     ]
 
     let output = try ConfigNormalizer().runtimeConfig(from: source, overrides: overrides, options: options)
@@ -2407,7 +2406,7 @@ final class ConfigNormalizerTests: XCTestCase {
       RuntimeSnippet(
         name: "Corp DNS",
         payload: .dnsPatch(TunDNSSettings(nameserver: ["https://corp.example/dns-query"]))
-      )
+      ),
     ]
 
     let output = try ConfigNormalizer().runtimeConfig(
@@ -2415,7 +2414,7 @@ final class ConfigNormalizerTests: XCTestCase {
       overrides: .defaultForLaunch(secret: "secret-token"),
       options: options
     )
-    let dns = try XCTUnwrap((try Yams.load(yaml: output) as? [String: Any])?["dns"] as? [String: Any])
+    let dns = try XCTUnwrap(try (Yams.load(yaml: output) as? [String: Any])?["dns"] as? [String: Any])
 
     XCTAssertEqual(dns["enable"] as? Bool, true)
     XCTAssertEqual(dns["nameserver"] as? [String], ["https://corp.example/dns-query"])
@@ -2429,7 +2428,7 @@ final class ConfigNormalizerTests: XCTestCase {
       RuntimeSnippet(
         name: "Corp DNS",
         payload: .dnsPatch(TunDNSSettings(nameserver: ["https://corp.example/dns-query"]))
-      )
+      ),
     ]
 
     let output = try ConfigNormalizer().runtimeConfig(
@@ -2437,7 +2436,7 @@ final class ConfigNormalizerTests: XCTestCase {
       overrides: overrides,
       options: options
     )
-    let dns = try XCTUnwrap((try Yams.load(yaml: output) as? [String: Any])?["dns"] as? [String: Any])
+    let dns = try XCTUnwrap(try (Yams.load(yaml: output) as? [String: Any])?["dns"] as? [String: Any])
 
     XCTAssertEqual(dns["enable"] as? Bool, false)
     XCTAssertEqual(dns["nameserver"] as? [String], ["https://corp.example/dns-query"])
@@ -2449,7 +2448,7 @@ final class ConfigNormalizerTests: XCTestCase {
       RuntimeSnippet(
         name: "Corp DNS",
         payload: .dnsPatch(TunDNSSettings(useHosts: true))
-      )
+      ),
     ]
 
     let output = try ConfigNormalizer().runtimeConfig(
@@ -2462,7 +2461,7 @@ final class ConfigNormalizerTests: XCTestCase {
       overrides: .defaultForLaunch(secret: "secret-token"),
       options: options
     )
-    let dns = try XCTUnwrap((try Yams.load(yaml: output) as? [String: Any])?["dns"] as? [String: Any])
+    let dns = try XCTUnwrap(try (Yams.load(yaml: output) as? [String: Any])?["dns"] as? [String: Any])
 
     // The profile explicitly said `false`, but nothing else does — enable it so the patch is real.
     XCTAssertEqual(dns["enable"] as? Bool, true)
@@ -2476,7 +2475,7 @@ final class ConfigNormalizerTests: XCTestCase {
       RuntimeSnippet(
         name: "Corp DNS",
         payload: .dnsPatch(TunDNSSettings(respectRules: true, nameserver: ["https://corp.example/dns-query"]))
-      )
+      ),
     ]
 
     XCTAssertThrowsError(
@@ -2503,7 +2502,7 @@ final class ConfigNormalizerTests: XCTestCase {
       RuntimeSnippet(
         name: "Corp DNS",
         payload: .dnsPatch(TunDNSSettings(respectRules: true))
-      )
+      ),
     ]
 
     let output = try ConfigNormalizer().runtimeConfig(
@@ -2516,7 +2515,7 @@ final class ConfigNormalizerTests: XCTestCase {
       overrides: .defaultForLaunch(secret: "secret-token"),
       options: options
     )
-    let dns = try XCTUnwrap((try Yams.load(yaml: output) as? [String: Any])?["dns"] as? [String: Any])
+    let dns = try XCTUnwrap(try (Yams.load(yaml: output) as? [String: Any])?["dns"] as? [String: Any])
 
     XCTAssertEqual(dns["enable"] as? Bool, true)
     XCTAssertEqual(dns["respect-rules"] as? Bool, true)
@@ -2530,7 +2529,7 @@ final class ConfigNormalizerTests: XCTestCase {
     overrides.dnsEnabled = false
     var options = RuntimeConfigOptions.default
     options.runtimeSnippets = [
-      RuntimeSnippet(name: "Corp DNS", payload: .dnsPatch(TunDNSSettings(respectRules: true)))
+      RuntimeSnippet(name: "Corp DNS", payload: .dnsPatch(TunDNSSettings(respectRules: true))),
     ]
 
     XCTAssertThrowsError(
@@ -2551,7 +2550,7 @@ final class ConfigNormalizerTests: XCTestCase {
       overrides: .defaultForLaunch(secret: "secret-token"),
       options: options
     )
-    let dns = try XCTUnwrap((try Yams.load(yaml: output) as? [String: Any])?["dns"] as? [String: Any])
+    let dns = try XCTUnwrap(try (Yams.load(yaml: output) as? [String: Any])?["dns"] as? [String: Any])
 
     XCTAssertEqual(dns["enable"] as? Bool, true)
     XCTAssertEqual(dns["respect-rules"] as? Bool, true)
@@ -2609,7 +2608,7 @@ final class ConfigNormalizerTests: XCTestCase {
       "proxy-groups: []\n",
       "tun:\n  enable: true\n",
       "dns:\n  listen: 0.0.0.0:53\n",
-      "dns:\n  fallback-filter:\n    script: true\n"
+      "dns:\n  fallback-filter:\n    script: true\n",
     ] {
       XCTAssertThrowsError(try RuntimeSnippetYAMLPatchParser.dnsPatch(from: unsafePatch))
     }
@@ -2691,7 +2690,7 @@ final class ConfigNormalizerTests: XCTestCase {
     overrides.ruleOverlay = RuleOverlaySettings(
       enabled: true,
       prependRules: [
-        ManagedRuleOverlayRule(kind: .domainSuffix, value: "bad,example", policy: "DIRECT")
+        ManagedRuleOverlayRule(kind: .domainSuffix, value: "bad,example", policy: "DIRECT"),
       ]
     )
 
@@ -2713,7 +2712,7 @@ final class ConfigNormalizerTests: XCTestCase {
     overrides.ruleOverlay = RuleOverlaySettings(
       enabled: true,
       disabledRuleMatchers: [
-        ManagedRuleDisableMatcher(mode: .regex, pattern: "[")
+        ManagedRuleDisableMatcher(mode: .regex, pattern: "["),
       ]
     )
 
@@ -2739,7 +2738,7 @@ final class ConfigNormalizerTests: XCTestCase {
         RuntimeRuleCandidate(
           rule: RuntimeRule(index: 1, type: "MATCH", payload: "", policy: "Proxy"),
           source: .runtimeProfile
-        )
+        ),
       ]
     }
 
@@ -2756,7 +2755,7 @@ final class ConfigNormalizerTests: XCTestCase {
         RuntimeRuleCandidate(
           rule: RuntimeRule(index: 1, type: "DOMAIN-SUFFIX", payload: "example.com", policy: "DIRECT"),
           source: .runtimeProfile
-        )
+        ),
       ]
     }
 
@@ -2777,7 +2776,7 @@ final class ConfigNormalizerTests: XCTestCase {
         RuntimeRuleCandidate(
           rule: RuntimeRule(index: 1, type: "DOMAIN-SUFFIX", payload: "example.com", policy: "DIRECT"),
           source: .globalPrepend
-        )
+        ),
       ]
     }
 
@@ -2793,7 +2792,7 @@ final class ConfigNormalizerTests: XCTestCase {
     let rules = [
       RuntimeRule(index: 1, type: "DOMAIN-SUFFIX", payload: "example.com", policy: "DIRECT"),
       RuntimeRule(index: 2, type: "DOMAIN-KEYWORD", payload: "example", policy: "Proxy"),
-      RuntimeRule(index: 3, type: "MATCH", payload: "", policy: "Proxy")
+      RuntimeRule(index: 3, type: "MATCH", payload: "", policy: "Proxy"),
     ]
 
     let outcome = RuleMatchSimulator().simulate(target: "api.example.com", rules: rules)
@@ -2809,7 +2808,7 @@ final class ConfigNormalizerTests: XCTestCase {
     let rules = [
       RuntimeRule(index: 1, type: "IP-CIDR", payload: "10.0.0.0/8", policy: "DIRECT"),
       RuntimeRule(index: 2, type: "IP-CIDR6", payload: "fd00::/8", policy: "DIRECT"),
-      RuntimeRule(index: 3, type: "MATCH", payload: "", policy: "Proxy")
+      RuntimeRule(index: 3, type: "MATCH", payload: "", policy: "Proxy"),
     ]
 
     let ipv4Outcome = RuleMatchSimulator().simulate(target: "10.1.2.3", rules: rules)
@@ -2833,7 +2832,7 @@ final class ConfigNormalizerTests: XCTestCase {
   func testRuleMatchSimulatorSupportsProcessRules() throws {
     let rules = [
       RuntimeRule(index: 1, type: "PROCESS-NAME", payload: "Safari", policy: "DIRECT"),
-      RuntimeRule(index: 2, type: "MATCH", payload: "", policy: "Proxy")
+      RuntimeRule(index: 2, type: "MATCH", payload: "", policy: "Proxy"),
     ]
 
     let outcome = RuleMatchSimulator().simulate(target: "/Applications/Safari.app", rules: rules)
@@ -2866,7 +2865,7 @@ final class ConfigNormalizerTests: XCTestCase {
       RuntimeRuleCandidate(
         rule: RuntimeRule(index: 5, type: "MATCH", payload: "", policy: "Fallback"),
         source: .globalAppend
-      )
+      ),
     ]
     let simulator = RuleMatchSimulator()
 
@@ -2904,28 +2903,28 @@ final class ConfigNormalizerTests: XCTestCase {
     let globalOverlay = RuleOverlaySettings(
       enabled: true,
       prependRules: [
-        ManagedRuleOverlayRule(kind: .domainSuffix, value: "global-pre.example", policy: "DIRECT")
+        ManagedRuleOverlayRule(kind: .domainSuffix, value: "global-pre.example", policy: "DIRECT"),
       ],
       appendRules: [
-        ManagedRuleOverlayRule(kind: .domainSuffix, value: "global-append.example", policy: "DIRECT")
+        ManagedRuleOverlayRule(kind: .domainSuffix, value: "global-append.example", policy: "DIRECT"),
       ]
     )
     let profileOverlay = RuleOverlaySettings(
       enabled: true,
       prependRules: [
-        ManagedRuleOverlayRule(kind: .domainSuffix, value: "profile-pre.example", policy: "Proxy")
+        ManagedRuleOverlayRule(kind: .domainSuffix, value: "profile-pre.example", policy: "Proxy"),
       ],
       appendRules: [
-        ManagedRuleOverlayRule(kind: .domainSuffix, value: "profile-append.example", policy: "Proxy")
+        ManagedRuleOverlayRule(kind: .domainSuffix, value: "profile-append.example", policy: "Proxy"),
       ]
     )
     let snippetOverlay = RuleOverlaySettings(
       enabled: true,
       prependRules: [
-        ManagedRuleOverlayRule(kind: .domainSuffix, value: "snippet-pre.example", policy: "DIRECT")
+        ManagedRuleOverlayRule(kind: .domainSuffix, value: "snippet-pre.example", policy: "DIRECT"),
       ],
       appendRules: [
-        ManagedRuleOverlayRule(kind: .domainSuffix, value: "snippet-append.example", policy: "DIRECT")
+        ManagedRuleOverlayRule(kind: .domainSuffix, value: "snippet-append.example", policy: "DIRECT"),
       ]
     )
     let runtimeRule = RuntimeRule(
@@ -2952,7 +2951,7 @@ final class ConfigNormalizerTests: XCTestCase {
         .runtimeProfile,
         .profileAppend,
         .globalAppend,
-        .runtimeSnippetAppend
+        .runtimeSnippetAppend,
       ]
     )
     XCTAssertEqual(candidates.map(\.rule.index), [1, 2, 3, 4, 5, 6, 7])
@@ -2965,7 +2964,7 @@ final class ConfigNormalizerTests: XCTestCase {
       ("api.runtime.example", .runtimeProfile),
       ("api.profile-append.example", .profileAppend),
       ("api.global-append.example", .globalAppend),
-      ("api.snippet-append.example", .runtimeSnippetAppend)
+      ("api.snippet-append.example", .runtimeSnippetAppend),
     ]
     for (destination, expectedSource) in matches {
       let trace = simulator.simulate(
@@ -3015,7 +3014,7 @@ final class ConfigNormalizerTests: XCTestCase {
       RuntimeRule(index: 2, type: "IP-CIDR", payload: "10.0.0.0/8", policy: "DIRECT"),
       RuntimeRule(index: 3, type: "PROCESS-NAME", payload: "Safari", policy: "DIRECT"),
       RuntimeRule(index: 4, type: "RULE-SET", payload: "OpenAI", policy: "Proxy"),
-      RuntimeRule(index: 5, type: "MATCH", payload: "", policy: "Fallback")
+      RuntimeRule(index: 5, type: "MATCH", payload: "", policy: "Fallback"),
     ]
     let builder = RuleExplanationBuilder()
 
@@ -3080,28 +3079,28 @@ final class ConfigNormalizerTests: XCTestCase {
       for: connection,
       rules: [
         RuntimeRule(index: 1, type: "DST-PORT", payload: "443", policy: "Proxy"),
-        RuntimeRule(index: 2, type: "MATCH", payload: "", policy: "Fallback")
+        RuntimeRule(index: 2, type: "MATCH", payload: "", policy: "Fallback"),
       ]
     )
     let sourcePort = builder.explanation(
       for: connection,
       rules: [
         RuntimeRule(index: 1, type: "SRC-PORT", payload: "50000-50100", policy: "DIRECT"),
-        RuntimeRule(index: 2, type: "MATCH", payload: "", policy: "Fallback")
+        RuntimeRule(index: 2, type: "MATCH", payload: "", policy: "Fallback"),
       ]
     )
     let inboundPort = builder.explanation(
       for: connection,
       rules: [
         RuntimeRule(index: 1, type: "IN-PORT", payload: "7890", policy: "Proxy"),
-        RuntimeRule(index: 2, type: "MATCH", payload: "", policy: "Fallback")
+        RuntimeRule(index: 2, type: "MATCH", payload: "", policy: "Fallback"),
       ]
     )
     let sourceIP = builder.explanation(
       for: connection,
       rules: [
         RuntimeRule(index: 1, type: "SRC-IP-CIDR", payload: "192.168.1.0/24", policy: "DIRECT"),
-        RuntimeRule(index: 2, type: "MATCH", payload: "", policy: "Fallback")
+        RuntimeRule(index: 2, type: "MATCH", payload: "", policy: "Fallback"),
       ]
     )
 

--- a/ClashMaxTests/CoreProcessControllerTests.swift
+++ b/ClashMaxTests/CoreProcessControllerTests.swift
@@ -1,6 +1,6 @@
+@testable import ClashMax
 import Foundation
 import XCTest
-@testable import ClashMax
 
 @MainActor
 final class CoreProcessControllerTests: XCTestCase {
@@ -173,7 +173,7 @@ final class CoreProcessControllerTests: XCTestCase {
     let signalSpy = ReaperSignalSpy(mode: .allow)
     let rowsProvider = ReaperRowsProvider(rows: [
       [(pid: fixture.pid, command: fixture.command)],
-      [(pid: fixture.pid, command: "/usr/bin/yes")]
+      [(pid: fixture.pid, command: "/usr/bin/yes")],
     ])
     let reaper = MihomoOrphanProcessReaper(
       terminationGracePeriod: 0,
@@ -282,7 +282,7 @@ final class CoreProcessControllerTests: XCTestCase {
     let launcher = FakeProcessLauncher()
     let portChecker = FakePortChecker(listeners: [
       PortListener(port: 9097, pid: 1234, command: "/opt/homebrew/bin/mihomo -f /tmp/other.yaml"),
-      PortListener(port: 7890, pid: 4321, command: "/usr/local/bin/proxy")
+      PortListener(port: 7890, pid: 4321, command: "/usr/local/bin/proxy"),
     ])
     let controller = CoreProcessController(
       launcher: launcher,

--- a/ClashMaxTests/CoreRuntimePreflightTests.swift
+++ b/ClashMaxTests/CoreRuntimePreflightTests.swift
@@ -1,6 +1,6 @@
+@testable import ClashMax
 import Foundation
 import XCTest
-@testable import ClashMax
 
 @MainActor
 final class CoreRuntimePreflightTests: XCTestCase {
@@ -521,7 +521,8 @@ private func waitForRecordedPID(at url: URL, timeout: TimeInterval = 1) async th
     if let text = try? String(contentsOf: url, encoding: .utf8)
       .trimmingCharacters(in: .whitespacesAndNewlines),
       let pid = pid_t(text),
-      pid > 1 {
+      pid > 1
+    {
       return pid
     }
     try await Task.sleep(nanoseconds: 20_000_000)
@@ -549,7 +550,7 @@ private func terminateTestProcessIfNeeded(_ pid: pid_t) {
   guard isProcessAlive(pid) else { return }
   kill(pid, SIGTERM)
   let deadline = Date().addingTimeInterval(1)
-  while Date() < deadline && isProcessAlive(pid) {
+  while Date() < deadline, isProcessAlive(pid) {
     usleep(20_000)
   }
   if isProcessAlive(pid) {

--- a/ClashMaxTests/DNSOverridePlanTests.swift
+++ b/ClashMaxTests/DNSOverridePlanTests.swift
@@ -1,6 +1,6 @@
+@testable import ClashMax
 import XCTest
 import Yams
-@testable import ClashMax
 
 /// Covers the pure classifier behind the Routing › DNS Override panel (issue #16).
 final class DNSOverridePlanTests: XCTestCase {
@@ -361,9 +361,9 @@ final class DNSOverridePlanTests: XCTestCase {
     finalYAML: String,
     sources: DNSOverrideSources = DNSOverrideSources()
   ) throws -> DNSOverridePlan {
-    DNSOverridePlanBuilder.plan(
-      baseline: try dnsFactsAllowingAbsent(baselineYAML),
-      final: try dnsFactsAllowingAbsent(finalYAML),
+    try DNSOverridePlanBuilder.plan(
+      baseline: dnsFactsAllowingAbsent(baselineYAML),
+      final: dnsFactsAllowingAbsent(finalYAML),
       sources: sources
     )
   }

--- a/ClashMaxTests/DashboardRuntimeStateTests.swift
+++ b/ClashMaxTests/DashboardRuntimeStateTests.swift
@@ -1,10 +1,10 @@
 import AppKit
+@testable import ClashMax
 import Observation
 import ServiceManagement
 import SwiftUI
 import XCTest
 import Yams
-@testable import ClashMax
 
 @MainActor
 final class DashboardRuntimeStateTests: XCTestCase {
@@ -36,10 +36,10 @@ final class DashboardRuntimeStateTests: XCTestCase {
 
   func testNoActiveProfileBlocksDashboard() throws {
     let paths = try Self.makeRuntimePaths()
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
 
     guard case let .blocked(reason) = model.dashboardRuntimeState else {
@@ -95,11 +95,11 @@ final class DashboardRuntimeStateTests: XCTestCase {
       in: paths.appSupport,
       rejectedToken: "never-matched"
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: profileStore,
       outboundProxyEndpointStore: endpointStore,
-      defaults: try Self.makeIsolatedDefaults(),
+      defaults: Self.makeIsolatedDefaults(),
       bundledCoreURLProvider: { preflightCore }
     )
 
@@ -133,11 +133,11 @@ final class DashboardRuntimeStateTests: XCTestCase {
       in: paths.appSupport,
       rejectedToken: "never-matched"
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: profileStore,
       outboundProxyEndpointStore: endpointStore,
-      defaults: try Self.makeIsolatedDefaults(),
+      defaults: Self.makeIsolatedDefaults(),
       bundledCoreURLProvider: { preflightCore }
     )
     let endpoint = OutboundProxyEndpoint(
@@ -192,11 +192,11 @@ final class DashboardRuntimeStateTests: XCTestCase {
       in: paths.appSupport,
       rejectedToken: "never-matched"
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: profileStore,
       outboundProxyEndpointStore: endpointStore,
-      defaults: try Self.makeIsolatedDefaults(),
+      defaults: Self.makeIsolatedDefaults(),
       bundledCoreURLProvider: { preflightCore }
     )
 
@@ -226,11 +226,11 @@ final class DashboardRuntimeStateTests: XCTestCase {
     )
     try await endpointStore.add(endpoint, password: nil)
     _ = try await profileStore.addManualProxyProfile(name: "Manual reference", endpointID: endpoint.id)
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: profileStore,
       outboundProxyEndpointStore: endpointStore,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
 
     let didDelete = await model.deleteOutboundProxyEndpoint(endpoint.id)
@@ -284,13 +284,13 @@ final class DashboardRuntimeStateTests: XCTestCase {
       in: paths.appSupport,
       rejectedToken: "never-matched"
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: profileStore,
       outboundProxyEndpointStore: endpointStore,
       coreController: controller,
       apiClient: client,
-      defaults: try Self.makeIsolatedDefaults(),
+      defaults: Self.makeIsolatedDefaults(),
       bundledCoreURLProvider: { preflightCore }
     )
     try await controller.startUserMode(
@@ -452,12 +452,12 @@ final class DashboardRuntimeStateTests: XCTestCase {
     )
     let client = RecordingMihomoController(proxyGroupsResponse: [], testDelayResult: 0)
     let preflightCore = try Self.makeRuleOverlayPreflightCore(in: paths.appSupport, rejectedToken: "never-matched")
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
       apiClient: client,
-      defaults: try Self.makeIsolatedDefaults(),
+      defaults: Self.makeIsolatedDefaults(),
       bundledCoreURLProvider: { preflightCore }
     )
     try await controller.startUserMode(
@@ -523,12 +523,12 @@ final class DashboardRuntimeStateTests: XCTestCase {
     // Validate the snippet preflight against a stub core instead of spawning the
     // real bundled mihomo, which the unsigned test host kills (SIGKILL → exit 9).
     let preflightCore = try Self.makeRuleOverlayPreflightCore(in: paths.appSupport, rejectedToken: "never-matched")
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
       apiClient: client,
-      defaults: try Self.makeIsolatedDefaults(),
+      defaults: Self.makeIsolatedDefaults(),
       bundledCoreURLProvider: { preflightCore }
     )
     try await controller.startUserMode(
@@ -544,7 +544,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
         RuleOverlaySettings(
           enabled: true,
           prependRules: [
-            ManagedRuleOverlayRule(kind: .domainSuffix, value: "inactive.example", policy: "DIRECT")
+            ManagedRuleOverlayRule(kind: .domainSuffix, value: "inactive.example", policy: "DIRECT"),
           ]
         )
       )
@@ -556,7 +556,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
         RuleOverlaySettings(
           enabled: true,
           prependRules: [
-            ManagedRuleOverlayRule(kind: .domainSuffix, value: "active.example", policy: "DIRECT")
+            ManagedRuleOverlayRule(kind: .domainSuffix, value: "active.example", policy: "DIRECT"),
           ]
         )
       )
@@ -575,7 +575,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
     XCTAssertEqual(model.lastRuntimeApplyOutcome, .applied(.rules))
     let reloadPaths = await client.reloadRequestPaths()
     XCTAssertEqual(reloadPaths.count, 1)
-    let runtimeConfig = try String(contentsOfFile: try XCTUnwrap(reloadPaths.first), encoding: .utf8)
+    let runtimeConfig = try String(contentsOfFile: XCTUnwrap(reloadPaths.first), encoding: .utf8)
     XCTAssertTrue(runtimeConfig.contains("DOMAIN-SUFFIX,active.example,DIRECT"))
     XCTAssertFalse(runtimeConfig.contains("inactive.example"))
   }
@@ -599,12 +599,12 @@ final class DashboardRuntimeStateTests: XCTestCase {
       reloadFailureMessage: "reload rejected"
     )
     let preflightCore = try Self.makeRuleOverlayPreflightCore(in: paths.appSupport, rejectedToken: "never-matched")
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
       apiClient: client,
-      defaults: try Self.makeIsolatedDefaults(),
+      defaults: Self.makeIsolatedDefaults(),
       bundledCoreURLProvider: { preflightCore }
     )
     await model.runtimeSnippetLibrary.waitForLoad()
@@ -615,7 +615,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
         RuleOverlaySettings(
           enabled: true,
           prependRules: [
-            ManagedRuleOverlayRule(kind: .domainSuffix, value: "stable.example", policy: "DIRECT")
+            ManagedRuleOverlayRule(kind: .domainSuffix, value: "stable.example", policy: "DIRECT"),
           ]
         )
       )
@@ -634,7 +634,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
         RuleOverlaySettings(
           enabled: true,
           prependRules: [
-            ManagedRuleOverlayRule(kind: .domainSuffix, value: "rejected.example", policy: "DIRECT")
+            ManagedRuleOverlayRule(kind: .domainSuffix, value: "rejected.example", policy: "DIRECT"),
           ]
         )
       )
@@ -691,12 +691,12 @@ final class DashboardRuntimeStateTests: XCTestCase {
     // Stub the preflight core (real bundled mihomo is SIGKILLed in the unsigned
     // test host); the preflight must pass so the reload step can be exercised.
     let preflightCore = try Self.makeRuleOverlayPreflightCore(in: paths.appSupport, rejectedToken: "never-matched")
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
       apiClient: client,
-      defaults: try Self.makeIsolatedDefaults(),
+      defaults: Self.makeIsolatedDefaults(),
       bundledCoreURLProvider: { preflightCore }
     )
     try await controller.startUserMode(
@@ -750,12 +750,12 @@ final class DashboardRuntimeStateTests: XCTestCase {
     exit 0
     """.write(to: fakeCoreURL, atomically: true, encoding: .utf8)
     try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: fakeCoreURL.path)
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
       apiClient: client,
-      defaults: try Self.makeIsolatedDefaults(),
+      defaults: Self.makeIsolatedDefaults(),
       bundledCoreURLProvider: { fakeCoreURL }
     )
     try await controller.startUserMode(
@@ -885,11 +885,11 @@ final class DashboardRuntimeStateTests: XCTestCase {
       nodes: [ProxyNode(name: "Japan", type: "vless", delay: nil, isSelectable: true)]
     )
     let client = RecordingMihomoController(proxyGroupsResponse: [group], testDelayResult: 73)
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       apiClient: client,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
 
     XCTAssertFalse(model.canControlRuntimeProxies)
@@ -917,12 +917,12 @@ final class DashboardRuntimeStateTests: XCTestCase {
       reaper: RecordingCoreProcessReaper(),
       portChecker: EmptyRuntimePortChecker()
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
       systemProxyController: SystemProxyController(commandRunner: RecordingCommandRunner(outputs: Self.defaultNetworkSetupOutputs())),
-      defaults: try Self.makeIsolatedDefaults(),
+      defaults: Self.makeIsolatedDefaults(),
       bundledCoreURLProvider: { URL(fileURLWithPath: "/tmp/mihomo") }
     )
     await model.waitForProfilePreviewRefresh()
@@ -993,12 +993,12 @@ final class DashboardRuntimeStateTests: XCTestCase {
       reaper: RecordingCoreProcessReaper(),
       portChecker: EmptyRuntimePortChecker()
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
       systemProxyController: SystemProxyController(commandRunner: RecordingCommandRunner(outputs: Self.defaultNetworkSetupOutputs())),
-      defaults: try Self.makeIsolatedDefaults(),
+      defaults: Self.makeIsolatedDefaults(),
       bundledCoreURLProvider: { URL(fileURLWithPath: "/tmp/mihomo") }
     )
     await model.waitForProfilePreviewRefresh()
@@ -1030,12 +1030,12 @@ final class DashboardRuntimeStateTests: XCTestCase {
       reaper: RecordingCoreProcessReaper(),
       portChecker: EmptyRuntimePortChecker()
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
       systemProxyController: SystemProxyController(commandRunner: RecordingCommandRunner(outputs: Self.defaultNetworkSetupOutputs())),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     let group = ProxyGroup(
       name: "Proxy",
@@ -1074,12 +1074,12 @@ final class DashboardRuntimeStateTests: XCTestCase {
       reaper: RecordingCoreProcessReaper(),
       portChecker: EmptyRuntimePortChecker()
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
       systemProxyController: SystemProxyController(commandRunner: RecordingCommandRunner(outputs: Self.defaultNetworkSetupOutputs())),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     await model.waitForProfilePreviewRefresh()
     model.warmPreviewRuntimeOnLaunch()
@@ -1115,12 +1115,12 @@ final class DashboardRuntimeStateTests: XCTestCase {
       reaper: RecordingCoreProcessReaper(),
       portChecker: EmptyRuntimePortChecker()
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
       systemProxyController: SystemProxyController(commandRunner: RecordingCommandRunner(outputs: Self.defaultNetworkSetupOutputs())),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     await model.waitForProfilePreviewRefresh()
     model.warmPreviewRuntimeOnLaunch()
@@ -1164,12 +1164,12 @@ final class DashboardRuntimeStateTests: XCTestCase {
       reaper: RecordingCoreProcessReaper(),
       portChecker: EmptyRuntimePortChecker()
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
       systemProxyController: SystemProxyController(commandRunner: RecordingCommandRunner(outputs: Self.defaultNetworkSetupOutputs())),
-      defaults: try Self.makeIsolatedDefaults(),
+      defaults: Self.makeIsolatedDefaults(),
       bundledCoreURLProvider: { URL(fileURLWithPath: "/tmp/mihomo") }
     )
     let didSelectFirstProfile = await model.selectProfileAsync(firstProfile)
@@ -1216,12 +1216,12 @@ final class DashboardRuntimeStateTests: XCTestCase {
       nodes: [ProxyNode(name: "Japan", type: "direct", delay: nil, isSelectable: true)]
     )
     let client = RecordingMihomoController(proxyGroupsResponse: [group], testDelayResult: 73)
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
       apiClient: client,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.proxyGroups = [group]
     try await controller.startUserMode(
@@ -1409,10 +1409,10 @@ final class DashboardRuntimeStateTests: XCTestCase {
 
   func testRuntimeDiagnosticsReportRedactsControllerSecret() throws {
     let paths = try Self.makeRuntimePaths()
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.externalControllerSettings = ExternalControllerSettings(
       host: "127.0.0.1",
@@ -1512,11 +1512,11 @@ final class DashboardRuntimeStateTests: XCTestCase {
       countryName: "United States"
     )
     let paths = try Self.makeRuntimePaths()
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
       publicIPInfoClient: RecordingPublicIPInfoFetcher(infos: [info]),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.tunnelCoreRunning = true
     model.proxyRoutingMode = ProxyRoutingMode.systemProxy
@@ -1528,9 +1528,9 @@ final class DashboardRuntimeStateTests: XCTestCase {
         selected: korean,
         nodes: [
           ProxyNode(name: "Provider: Remote", type: "provider", delay: nil, isSelectable: true),
-          ProxyNode(name: "DIRECT", type: "direct", delay: nil, isSelectable: true)
+          ProxyNode(name: "DIRECT", type: "direct", delay: nil, isSelectable: true),
         ]
-      )
+      ),
     ]
     model.proxyProviders = [
       ProxyProvider(
@@ -1539,7 +1539,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
         vehicleType: nil,
         updatedAt: nil,
         proxies: [ProxyNode(name: korean, type: "trojan", delay: 142, isSelectable: true)]
-      )
+      ),
     ]
     model.refreshPublicIPInfo(force: true)
     try await Self.waitForPublicIPInfo(model, expectedIP: "198.51.100.9")
@@ -1602,13 +1602,13 @@ final class DashboardRuntimeStateTests: XCTestCase {
     let overlay = RuleOverlaySettings(
       enabled: true,
       prependRules: [
-        ManagedRuleOverlayRule(kind: .domainSuffix, value: "corp.example", policy: "DIRECT")
+        ManagedRuleOverlayRule(kind: .domainSuffix, value: "corp.example", policy: "DIRECT"),
       ],
       appendRules: [
-        ManagedRuleOverlayRule(kind: .match, policy: "Proxy")
+        ManagedRuleOverlayRule(kind: .match, policy: "Proxy"),
       ],
       disabledRuleMatchers: [
-        ManagedRuleDisableMatcher(mode: .contains, pattern: "ads.example")
+        ManagedRuleDisableMatcher(mode: .contains, pattern: "ads.example"),
       ]
     )
 
@@ -1654,7 +1654,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
     let overlay = RuleOverlaySettings(
       enabled: true,
       prependRules: [
-        ManagedRuleOverlayRule(kind: .domainSuffix, value: "bad-preflight.example", policy: "DIRECT")
+        ManagedRuleOverlayRule(kind: .domainSuffix, value: "bad-preflight.example", policy: "DIRECT"),
       ]
     )
 
@@ -1691,7 +1691,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
     let overlay = RuleOverlaySettings(
       enabled: true,
       prependRules: [
-        ManagedRuleOverlayRule(kind: .domainSuffix, value: "bad-preflight.example", policy: "DIRECT")
+        ManagedRuleOverlayRule(kind: .domainSuffix, value: "bad-preflight.example", policy: "DIRECT"),
       ]
     )
 
@@ -1720,12 +1720,12 @@ final class DashboardRuntimeStateTests: XCTestCase {
     )
     let client = RecordingMihomoController(proxyGroupsResponse: [], testDelayResult: 0)
     let preflightCore = try Self.makeRuleOverlayPreflightCore(in: paths.appSupport, rejectedToken: "never-matched")
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
       apiClient: client,
-      defaults: try Self.makeIsolatedDefaults(),
+      defaults: Self.makeIsolatedDefaults(),
       bundledCoreURLProvider: { preflightCore }
     )
     try await controller.startUserMode(
@@ -1737,7 +1737,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
     let overlay = RuleOverlaySettings(
       enabled: true,
       prependRules: [
-        ManagedRuleOverlayRule(kind: .domainSuffix, value: "live.example", policy: "DIRECT")
+        ManagedRuleOverlayRule(kind: .domainSuffix, value: "live.example", policy: "DIRECT"),
       ]
     )
 
@@ -1748,7 +1748,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
     XCTAssertEqual(model.lastRuntimeApplyOutcome, .applied(.rules))
     let reloadPaths = await client.reloadRequestPaths()
     XCTAssertEqual(reloadPaths.count, 1)
-    let runtimeConfig = try String(contentsOfFile: try XCTUnwrap(reloadPaths.first), encoding: .utf8)
+    let runtimeConfig = try String(contentsOfFile: XCTUnwrap(reloadPaths.first), encoding: .utf8)
     XCTAssertTrue(runtimeConfig.contains("DOMAIN-SUFFIX,live.example,DIRECT"))
   }
 
@@ -1783,7 +1783,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
     let stableOverlay = RuleOverlaySettings(
       enabled: true,
       prependRules: [
-        ManagedRuleOverlayRule(kind: .domainSuffix, value: "stable.example", policy: "DIRECT")
+        ManagedRuleOverlayRule(kind: .domainSuffix, value: "stable.example", policy: "DIRECT"),
       ]
     )
     model.ruleOverlaySettings = stableOverlay
@@ -1796,7 +1796,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
     let rejectedOverlay = RuleOverlaySettings(
       enabled: true,
       prependRules: [
-        ManagedRuleOverlayRule(kind: .domainSuffix, value: "rejected.example", policy: "DIRECT")
+        ManagedRuleOverlayRule(kind: .domainSuffix, value: "rejected.example", policy: "DIRECT"),
       ]
     )
 
@@ -1833,7 +1833,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
         "strictRoute": true,
         "autoDetectInterface": false,
         "dnsHijack": ["any:53"],
-        "mtu": 1400
+        "mtu": 1400,
       ],
       forKey: Self.tunSettingsDefaultsKey,
       defaults: defaults
@@ -1894,7 +1894,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
         "fakeIPRange": "198.18.0.1/16",
         "systemDNSOverrideEnabled": true,
         "systemDNSServers": ["114.114.114.114"],
-        "dns": [:]
+        "dns": [:],
       ],
       forKey: Self.tunSettingsDefaultsKey,
       defaults: defaults
@@ -1929,8 +1929,8 @@ final class DashboardRuntimeStateTests: XCTestCase {
         "systemDNSServers": ["114.114.114.114"],
         "dns": [
           "nameserver": ["https://dns.example/dns-query"],
-          "fakeIPFilter": ["*.custom"]
-        ]
+          "fakeIPFilter": ["*.custom"],
+        ],
       ],
       forKey: Self.tunSettingsDefaultsKey,
       defaults: defaults
@@ -1997,10 +1997,10 @@ final class DashboardRuntimeStateTests: XCTestCase {
 
   func testUpdatingTunSettingsRejectsInvalidCIDRAndSystemDNS() throws {
     let paths = try Self.makeRuntimePaths()
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
 
     var settings = TunSettings.default
@@ -2048,7 +2048,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
         "enabled": false,
         "host": "localhost",
         "port": 19197,
-        "secret": "saved-secret"
+        "secret": "saved-secret",
       ],
       forKey: Self.externalControllerSettingsDefaultsKey,
       defaults: defaults
@@ -2091,7 +2091,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
     XCTAssertTrue(model.saveExternalDashboardProfile(profile, secret: "dashboard-secret"))
     let saved = try XCTUnwrap(model.externalDashboardProfiles.first { $0.name == "Local YACD" })
     let account = try XCTUnwrap(saved.secretAccount)
-    let encodedProfiles = String(data: try JSONEncoder().encode(model.externalDashboardProfiles), encoding: .utf8)
+    let encodedProfiles = try String(data: JSONEncoder().encode(model.externalDashboardProfiles), encoding: .utf8)
 
     XCTAssertEqual(dashboardSecrets.storedValues[account], "dashboard-secret")
     XCTAssertFalse(encodedProfiles?.contains("dashboard-secret") == true)
@@ -2217,8 +2217,8 @@ final class DashboardRuntimeStateTests: XCTestCase {
         "port": 19198,
         "secret": "saved-secret",
         "cors": [
-          "enabled": true
-        ]
+          "enabled": true,
+        ],
       ],
       forKey: Self.externalControllerSettingsDefaultsKey,
       defaults: defaults
@@ -2258,9 +2258,9 @@ final class DashboardRuntimeStateTests: XCTestCase {
             "https://custom.example",
             "https://yacd.metacubex.one",
             "https://metacubex.github.io",
-            "https://board.zash.run.place"
-          ]
-        ]
+            "https://board.zash.run.place",
+          ],
+        ],
       ],
       forKey: Self.externalControllerSettingsDefaultsKey,
       defaults: defaults
@@ -2288,7 +2288,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
         "logLevel": "debug",
         "unifiedDelay": true,
         "dnsEnabled": true,
-        "tunEnabled": true
+        "tunEnabled": true,
       ]
     )
 
@@ -2315,7 +2315,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
     try Self.storeJSON(
       [
         "mode": "nativePing",
-        "unifiedDelay": true
+        "unifiedDelay": true,
       ],
       forKey: Self.delayTestSettingsDefaultsKey,
       defaults: defaults
@@ -2348,7 +2348,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
       closesOldConnectionsAfterSwitch: true,
       customDelayTestURLsByGroupName: [
         "Proxy": " https://example.com/delay ",
-        "Auto": "https://example.com/auto"
+        "Auto": "https://example.com/auto",
       ]
     )
 
@@ -2380,8 +2380,8 @@ final class DashboardRuntimeStateTests: XCTestCase {
         "sortOrder": "delay",
         "customDelayTestURLsByGroupName": [
           " Proxy ": " https://example.com/delay ",
-          "Empty": ""
-        ]
+          "Empty": "",
+        ],
       ],
       forKey: Self.proxyPageSettingsDefaultsKey,
       defaults: defaults
@@ -2439,7 +2439,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
         "customBypassDomains": ["localhost", "*.corp"],
         "useDefaultBypass": false,
         "validateBypass": false,
-        "guardEnabled": true
+        "guardEnabled": true,
       ],
       forKey: Self.systemProxySettingsDefaultsKey,
       defaults: defaults
@@ -2467,7 +2467,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
         "useDefaultBypass": false,
         "validateBypass": false,
         "guardEnabled": true,
-        "guardIntervalSeconds": "slow"
+        "guardIntervalSeconds": "slow",
       ]
     )
 
@@ -2490,8 +2490,8 @@ final class DashboardRuntimeStateTests: XCTestCase {
           " https://custom.example ",
           "https://custom.example",
           "\n",
-          "HTTPS://PANEL.EXAMPLE"
-        ]
+          "HTTPS://PANEL.EXAMPLE",
+        ],
       ]
     )
 
@@ -2512,12 +2512,12 @@ final class DashboardRuntimeStateTests: XCTestCase {
           "",
           "\n",
           " *.corp ",
-          "*.corp"
+          "*.corp",
         ],
         "useDefaultBypass": false,
         "validateBypass": true,
         "guardEnabled": true,
-        "guardIntervalSeconds": 10
+        "guardIntervalSeconds": 10,
       ]
     )
 
@@ -2569,7 +2569,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
             ssid: "CorpWiFi",
             proxyRoutingMode: .systemProxy,
             enableSystemProxy: true
-          )
+          ),
         ]
       )
     )
@@ -2796,11 +2796,11 @@ final class DashboardRuntimeStateTests: XCTestCase {
 
   func testLaunchAtLoginRequiresApprovalReportsToggleOffWithApprovalMessage() async throws {
     let paths = try Self.makeRuntimePaths()
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
       loginItemService: FakeLoginItemService(status: .requiresApproval),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
 
     XCTAssertFalse(model.launchSettings.launchAtLogin)
@@ -2850,11 +2850,11 @@ final class DashboardRuntimeStateTests: XCTestCase {
 
     // Not desired: never registers.
     let notDesired = FakeLoginItemService(status: .notRegistered)
-    let notDesiredModel = AppModel(
+    let notDesiredModel = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
       loginItemService: notDesired,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     notDesiredModel.repairLaunchAtLoginRegistrationOnLaunch()
     XCTAssertEqual(notDesired.registerCount, 0)
@@ -2915,11 +2915,11 @@ final class DashboardRuntimeStateTests: XCTestCase {
         userInfo: [NSLocalizedDescriptionKey: "registration denied"]
       )
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
       loginItemService: service,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
 
     model.setLaunchAtLogin(true)
@@ -3132,10 +3132,10 @@ final class DashboardRuntimeStateTests: XCTestCase {
   /// The bug as reported: connected to Wi-Fi, but Settings only ever said "No Wi-Fi SSID detected."
   func testRefreshReportsLocationAuthorizationInsteadOfBareNoSSIDMessage() throws {
     let paths = try Self.makeRuntimePaths()
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
-      defaults: try Self.makeIsolatedDefaults(),
+      defaults: Self.makeIsolatedDefaults(),
       currentNetworkProvider: StaticCurrentNetworkProvider(unavailable: .locationAuthorizationNotDetermined)
     )
 
@@ -3166,11 +3166,11 @@ final class DashboardRuntimeStateTests: XCTestCase {
       proxyRoutingMode: .systemProxy,
       enableSystemProxy: true
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
       systemProxyController: SystemProxyController(commandRunner: commandRunner),
-      defaults: try Self.makeIsolatedDefaults(),
+      defaults: Self.makeIsolatedDefaults(),
       currentNetworkProvider: provider
     )
     model.setProxyRoutingMode(.neProxy)
@@ -3218,12 +3218,12 @@ final class DashboardRuntimeStateTests: XCTestCase {
       portChecker: EmptyRuntimePortChecker()
     )
     let runner = GateableCommandRunner(outputs: Self.defaultNetworkSetupOutputs())
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
       systemProxyController: SystemProxyController(commandRunner: runner),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
 
     // Bring the core up so leaving System Proxy will trigger a restart.
@@ -3308,12 +3308,12 @@ final class DashboardRuntimeStateTests: XCTestCase {
       portChecker: EmptyRuntimePortChecker()
     )
     let runner = FailableCommandRunner(outputs: Self.defaultNetworkSetupOutputs())
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
       systemProxyController: SystemProxyController(commandRunner: runner),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
 
     try await controller.startUserMode(
@@ -3431,7 +3431,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
       proxyRoutingMode: .neProxy,
       enableSystemProxy: false
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
@@ -3441,7 +3441,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
         transparentProxyManager: proxyManager
       ),
       proxyPortReadinessProbe: RecordingProxyPortReadinessProbe(),
-      defaults: try Self.makeIsolatedDefaults(),
+      defaults: Self.makeIsolatedDefaults(),
       currentNetworkProvider: provider,
       bundledCoreURLProvider: { URL(fileURLWithPath: "/tmp/mihomo") }
     )
@@ -3550,11 +3550,11 @@ final class DashboardRuntimeStateTests: XCTestCase {
       proxyRoutingMode: .systemProxy,
       enableSystemProxy: true
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
       systemProxyController: controller,
-      defaults: try Self.makeIsolatedDefaults(),
+      defaults: Self.makeIsolatedDefaults(),
       currentNetworkProvider: provider
     )
     model.networkPolicySettings = NetworkPolicySettings(rules: [rule], autoApplyEnabled: true)
@@ -3617,10 +3617,10 @@ final class DashboardRuntimeStateTests: XCTestCase {
     let paths = try Self.makeRuntimePaths()
     let monitor = ManualNetworkEnvironmentMonitor()
     let rule = NetworkPolicyRule(name: "Office Wi-Fi", ssid: "CorpNet", proxyRoutingMode: .systemProxy)
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
-      defaults: try Self.makeIsolatedDefaults(),
+      defaults: Self.makeIsolatedDefaults(),
       currentNetworkProvider: StaticCurrentNetworkProvider(ssid: "corpnet"),
       networkEnvironmentMonitor: monitor
     )
@@ -3649,12 +3649,12 @@ final class DashboardRuntimeStateTests: XCTestCase {
       reaper: RecordingCoreProcessReaper(),
       portChecker: EmptyRuntimePortChecker()
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
       systemProxyController: SystemProxyController(commandRunner: RecordingCommandRunner(outputs: Self.defaultNetworkSetupOutputs())),
-      defaults: try Self.makeIsolatedDefaults(),
+      defaults: Self.makeIsolatedDefaults(),
       bundledCoreURLProvider: { URL(fileURLWithPath: "/tmp/mihomo") }
     )
     await model.waitForProfilePreviewRefresh()
@@ -3682,14 +3682,14 @@ final class DashboardRuntimeStateTests: XCTestCase {
     let paths = try Self.makeRuntimePaths()
     let commandRunner = RecordingCommandRunner(outputs: Self.defaultNetworkSetupOutputs())
     let controller = SystemProxyController(commandRunner: commandRunner)
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
       systemProxyController: controller,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
 
-    model.handleIncomingURL(try XCTUnwrap(URL(string: "clashmax://toggle-system-proxy")))
+    try model.handleIncomingURL(XCTUnwrap(URL(string: "clashmax://toggle-system-proxy")))
 
     for _ in 0..<40 where !model.systemProxyEnabled {
       await Task.yield()
@@ -3922,11 +3922,11 @@ final class DashboardRuntimeStateTests: XCTestCase {
         "Enabled: Yes\nServer: 127.0.0.1\nPort: 17890\n",
         "Enabled: Yes\nServer: 127.0.0.1\nPort: 17890\n",
         "Enabled: No\nServer:\nPort: 0\n",
-        "Enabled: No\nServer:\nPort: 0\n"
+        "Enabled: No\nServer:\nPort: 0\n",
       ],
       "/usr/sbin/networksetup -getsecurewebproxy Wi-Fi": Array(repeating: "Enabled: No\nServer:\nPort: 0\n", count: 6),
       "/usr/sbin/networksetup -getsocksfirewallproxy Wi-Fi": Array(repeating: "Enabled: No\nServer:\nPort: 0\n", count: 6),
-      "/usr/sbin/networksetup -getproxybypassdomains Wi-Fi": Array(repeating: "There aren't any bypass domains set.\n", count: 6)
+      "/usr/sbin/networksetup -getproxybypassdomains Wi-Fi": Array(repeating: "There aren't any bypass domains set.\n", count: 6),
     ])
     let controller = SystemProxyController(commandRunner: commandRunner, snapshotDefaults: defaults)
     let model = AppModel(
@@ -4107,7 +4107,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
   func testProxyNodeSorterKeepsProfileOrderButSortsByNameOnDemand() {
     let nodes = [
       ProxyNode(name: "z", type: "vless", delay: nil, isSelectable: true),
-      ProxyNode(name: "a", type: "vless", delay: nil, isSelectable: true)
+      ProxyNode(name: "a", type: "vless", delay: nil, isSelectable: true),
     ]
 
     XCTAssertEqual(ProxyNodeSorter.sorted(nodes, by: .profile).map(\.name), ["z", "a"])
@@ -4162,7 +4162,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
         type: "select",
         selected: "Japan",
         nodes: [ProxyNode(name: "Japan", type: "vless", delay: nil, isSelectable: true)]
-      )
+      ),
     ]
 
     let initialExpansion = ProxyGroupExpansionPolicy.resolvedExpansion(
@@ -4180,7 +4180,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
       LogEntry(level: "info", message: "Core ready"),
       LogEntry(level: "debug", message: "controller request body"),
       LogEntry(level: "info", message: "GET https://www.gstatic.com/generate_204"),
-      LogEntry(level: "trace", message: "raw stream frame")
+      LogEntry(level: "trace", message: "raw stream frame"),
     ]
 
     let normalMessages = LogVisibility.visibleEntries(in: entries, developerMode: false).map(\.message)
@@ -4198,7 +4198,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
     let entries = [
       LogEntry(level: "info", message: "Core ready"),
       LogEntry(level: "debug", message: "controller request body"),
-      LogEntry(level: "trace", message: "raw stream frame")
+      LogEntry(level: "trace", message: "raw stream frame"),
     ]
 
     let quietMessages = LogVisibility
@@ -4229,10 +4229,10 @@ final class DashboardRuntimeStateTests: XCTestCase {
 
   func testUserVisibleLogsFollowSelectedLogLevel() throws {
     let paths = try Self.makeRuntimePaths()
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.overrides.logLevel = "info"
     model.runtimeData.appendLog(level: "info", message: "Core ready")
@@ -4254,10 +4254,10 @@ final class DashboardRuntimeStateTests: XCTestCase {
   /// deliberately turned on has to be in it (discussion #25).
   func testRuntimeDiagnosticsReportIncludesDebugLogsAtDebugLevel() throws {
     let paths = try Self.makeRuntimePaths()
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.overrides.logLevel = "debug"
     model.runtimeData.appendLog(level: "debug", message: "dns resolve example.com")
@@ -4318,7 +4318,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
   func testProxyGroupExpansionDefaultsToSelectedGroup() {
     let groups = [
       ProxyGroup(name: "General", type: "select", selected: nil, nodes: []),
-      ProxyGroup(name: "Streaming", type: "select", selected: "Japan", nodes: [])
+      ProxyGroup(name: "Streaming", type: "select", selected: "Japan", nodes: []),
     ]
 
     XCTAssertEqual(
@@ -4330,7 +4330,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
   func testProxyGroupExpansionDefaultsToFirstGroupWithoutSelection() {
     let groups = [
       ProxyGroup(name: "General", type: "select", selected: nil, nodes: []),
-      ProxyGroup(name: "Streaming", type: "select", selected: nil, nodes: [])
+      ProxyGroup(name: "Streaming", type: "select", selected: nil, nodes: []),
     ]
 
     XCTAssertEqual(
@@ -4342,7 +4342,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
   func testProxyGroupExpansionRetainsExistingGroupsAfterRefresh() {
     let refreshedGroups = [
       ProxyGroup(name: "General", type: "select", selected: nil, nodes: []),
-      ProxyGroup(name: "Auto", type: "url-test", selected: nil, nodes: [])
+      ProxyGroup(name: "Auto", type: "url-test", selected: nil, nodes: []),
     ]
 
     XCTAssertEqual(
@@ -4354,7 +4354,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
   func testProxyGroupExpansionOpensSearchResults() {
     let groups = [
       ProxyGroup(name: "General", type: "select", selected: nil, nodes: []),
-      ProxyGroup(name: "Streaming", type: "select", selected: nil, nodes: [])
+      ProxyGroup(name: "Streaming", type: "select", selected: nil, nodes: []),
     ]
 
     XCTAssertEqual(
@@ -4371,7 +4371,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
         selected: "Singapore",
         nodes: [
           ProxyNode(name: "Singapore", type: "proxy", delay: 82, isSelectable: true),
-          ProxyNode(name: "DIRECT", type: "direct", delay: nil, isSelectable: false)
+          ProxyNode(name: "DIRECT", type: "direct", delay: nil, isSelectable: false),
         ]
       ),
       ProxyGroup(
@@ -4380,9 +4380,9 @@ final class DashboardRuntimeStateTests: XCTestCase {
         selected: "Japan",
         nodes: [
           ProxyNode(name: "Japan", type: "hysteria2", delay: 157, isSelectable: true),
-          ProxyNode(name: "Hong Kong", type: "vless", delay: 64, isSelectable: true)
+          ProxyNode(name: "Hong Kong", type: "vless", delay: 64, isSelectable: true),
         ]
-      )
+      ),
     ]
 
     let group = try XCTUnwrap(DashboardProxySelectionState.resolvedGroup(from: groups, preferredName: "Streaming"))
@@ -4406,9 +4406,9 @@ final class DashboardRuntimeStateTests: XCTestCase {
         type: "Selector",
         selected: nil,
         nodes: [
-          ProxyNode(name: "Tokyo", type: "vless", delay: nil, isSelectable: true)
+          ProxyNode(name: "Tokyo", type: "vless", delay: nil, isSelectable: true),
         ]
-      )
+      ),
     ]
 
     let group = try XCTUnwrap(DashboardProxySelectionState.resolvedGroup(from: groups, preferredName: "Missing"))
@@ -4427,7 +4427,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
         selected: "Japan",
         nodes: [
           ProxyNode(name: "Japan", type: "vless", delay: nil, isSelectable: true),
-          ProxyNode(name: "Singapore", type: "vless", delay: nil, isSelectable: true)
+          ProxyNode(name: "Singapore", type: "vless", delay: nil, isSelectable: true),
         ]
       ),
       ProxyGroup(
@@ -4436,7 +4436,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
         selected: "Singapore",
         nodes: [
           ProxyNode(name: "Japan", type: "vless", delay: nil, isSelectable: true),
-          ProxyNode(name: "Singapore", type: "vless", delay: nil, isSelectable: true)
+          ProxyNode(name: "Singapore", type: "vless", delay: nil, isSelectable: true),
         ]
       ),
       ProxyGroup(
@@ -4445,9 +4445,9 @@ final class DashboardRuntimeStateTests: XCTestCase {
         selected: "Japan",
         nodes: [
           ProxyNode(name: "Japan", type: "vless", delay: nil, isSelectable: true),
-          ProxyNode(name: "DIRECT", type: "direct", delay: nil, isSelectable: true)
+          ProxyNode(name: "DIRECT", type: "direct", delay: nil, isSelectable: true),
         ]
-      )
+      ),
     ]
 
     XCTAssertEqual(DashboardProxySelectionState.selectableGroups(from: groups).map(\.name), ["Elite"])
@@ -4466,7 +4466,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
       type: "select",
       selected: "韩国 SK[M][Trojan][倍率:0.6]",
       nodes: [
-        ProxyNode(name: "DIRECT", type: "direct", delay: nil, isSelectable: true)
+        ProxyNode(name: "DIRECT", type: "direct", delay: nil, isSelectable: true),
       ]
     )
 
@@ -4482,7 +4482,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
       selected: nil,
       nodes: [
         ProxyNode(name: "DIRECT", type: "direct", delay: nil, isSelectable: true),
-        ProxyNode(name: "Tokyo", type: "vless", delay: 64, isSelectable: true)
+        ProxyNode(name: "Tokyo", type: "vless", delay: 64, isSelectable: true),
       ]
     )
 
@@ -4500,7 +4500,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
       selected: korean,
       nodes: [
         ProxyNode(name: "Provider: Remote", type: "provider", delay: nil, isSelectable: true),
-        ProxyNode(name: "DIRECT", type: "direct", delay: nil, isSelectable: true)
+        ProxyNode(name: "DIRECT", type: "direct", delay: nil, isSelectable: true),
       ]
     )
     let provider = ProxyProvider(
@@ -4511,7 +4511,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
       proxies: [ProxyNode(name: korean, type: "trojan", delay: 142, isSelectable: true)]
     )
 
-    let model = AppModel(paths: try Self.makeRuntimePaths(), defaults: try Self.makeIsolatedDefaults())
+    let model = try AppModel(paths: Self.makeRuntimePaths(), defaults: Self.makeIsolatedDefaults())
     model.profilePreviewGroups = [group]
     model.proxyProviders = [provider]
 
@@ -4551,7 +4551,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
       selected: korean,
       nodes: [
         ProxyNode(name: "Provider: Remote", type: "provider", delay: nil, isSelectable: true),
-        ProxyNode(name: "DIRECT", type: "direct", delay: nil, isSelectable: true)
+        ProxyNode(name: "DIRECT", type: "direct", delay: nil, isSelectable: true),
       ]
     )
     let provider = ProxyProvider(
@@ -4562,7 +4562,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
       proxies: [ProxyNode(name: korean, type: "trojan", delay: 142, isSelectable: true)]
     )
 
-    let model = AppModel(paths: try Self.makeRuntimePaths(), defaults: try Self.makeIsolatedDefaults())
+    let model = try AppModel(paths: Self.makeRuntimePaths(), defaults: Self.makeIsolatedDefaults())
     model.profilePreviewGroups = [group]
     model.proxyProviders = [provider]
 
@@ -4637,12 +4637,12 @@ final class DashboardRuntimeStateTests: XCTestCase {
       proxyGroupsResponse: [group],
       testDelayResult: 73
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
       apiClient: client,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.proxyGroups = [group]
 
@@ -4691,12 +4691,12 @@ final class DashboardRuntimeStateTests: XCTestCase {
       proxyGroupsResponse: [group],
       testDelayResults: [111, 73]
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
       apiClient: client,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.delayTestSettings = DelayTestSettings(mode: .mihomoURL, unifiedDelay: true)
     model.proxyGroups = [group]
@@ -4744,13 +4744,13 @@ final class DashboardRuntimeStateTests: XCTestCase {
     )
     let client = RecordingMihomoController(proxyGroupsResponse: [group], testDelayResult: 99)
     let pingTester = RecordingPingTester(results: [44])
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
       apiClient: client,
       pingTester: pingTester,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     await model.waitForProfilePreviewRefresh()
     model.delayTestSettings = DelayTestSettings(mode: .nativePing, unifiedDelay: false)
@@ -4807,13 +4807,13 @@ final class DashboardRuntimeStateTests: XCTestCase {
     )
     let client = RecordingMihomoController(proxyGroupsResponse: [runtimeGroup], testDelayResult: 99)
     let pingTester = RecordingPingTester(results: [51])
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
       apiClient: client,
       pingTester: pingTester,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     await model.waitForProfilePreviewRefresh()
     model.delayTestSettings = DelayTestSettings(mode: .nativePing, unifiedDelay: false)
@@ -4886,7 +4886,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
           isSelectable: true,
           serverHost: "provider.example",
           serverPort: 443
-        )
+        ),
       ]
     )
     let client = RecordingMihomoController(
@@ -4895,13 +4895,13 @@ final class DashboardRuntimeStateTests: XCTestCase {
       testDelayResult: 99
     )
     let pingTester = RecordingPingTester(results: [62])
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
       apiClient: client,
       pingTester: pingTester,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.delayTestSettings = DelayTestSettings(mode: .nativePing, unifiedDelay: false)
 
@@ -4958,13 +4958,13 @@ final class DashboardRuntimeStateTests: XCTestCase {
     )
     let client = RecordingMihomoController(proxyGroupsResponse: [group], testDelayResult: 99)
     let pingTester = RecordingPingTester(results: [44])
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
       apiClient: client,
       pingTester: pingTester,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.delayTestSettings = DelayTestSettings(mode: .nativePing, unifiedDelay: false)
     model.proxyGroups = [group]
@@ -5042,7 +5042,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
           type: "select",
           selected: "Japan",
           nodes: [ProxyNode(name: "Japan", type: "vless", delay: nil, isSelectable: true)]
-        )
+        ),
       ],
       proxyProvidersResponse: [provider],
       ruleProvidersResponse: [ruleProvider],
@@ -5122,7 +5122,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
           type: "select",
           selected: "Japan",
           nodes: [ProxyNode(name: "Japan", type: "vless", delay: nil, isSelectable: true)]
-        )
+        ),
       ],
       testDelayResult: 73,
       proxyGroupsDelayNanoseconds: 200_000_000
@@ -5159,7 +5159,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
           type: "select",
           selected: "Japan",
           nodes: [ProxyNode(name: "Japan", type: "vless", delay: nil, isSelectable: true)]
-        )
+        ),
       ],
       testDelayResult: 73,
       proxyGroupsDelayNanoseconds: 200_000_000
@@ -5237,10 +5237,11 @@ final class DashboardRuntimeStateTests: XCTestCase {
     for _ in 0..<80 {
       let healthCheckCount = await client.healthCheckRequestCount()
       let closedConnectionIDs = await client.closedConnectionIDs()
-      if healthCheckCount > 0
-        && !closedConnectionIDs.isEmpty
-        && model.closingConnectionIDs.isEmpty
-        && model.connections.isEmpty {
+      if healthCheckCount > 0,
+         !closedConnectionIDs.isEmpty,
+         model.closingConnectionIDs.isEmpty,
+         model.connections.isEmpty
+      {
         break
       }
       await Task.yield()
@@ -5258,7 +5259,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
 
     for _ in 0..<80 {
       let closeAllRequestCount = await client.closeAllRequestCount()
-      if closeAllRequestCount > 0 && !model.closingAllConnections && model.connections.isEmpty {
+      if closeAllRequestCount > 0, !model.closingAllConnections, model.connections.isEmpty {
         break
       }
       await Task.yield()
@@ -5355,7 +5356,8 @@ final class DashboardRuntimeStateTests: XCTestCase {
       if client.subscriptionCounts() == [1, 1, 1],
          client.connectionRequestCount() >= 1,
          !model.runtimeDataLoading,
-         model.runtimeSettingsApplyState == .idle {
+         model.runtimeSettingsApplyState == .idle
+      {
         break
       }
       await Task.yield()
@@ -5371,7 +5373,8 @@ final class DashboardRuntimeStateTests: XCTestCase {
     for _ in 0..<300 {
       model.runtimeData.flushPendingLogs()
       if model.trafficSample == TrafficSample(upload: 11, download: 22),
-         model.logs.contains(where: { $0.message == "first stream" }) {
+         model.logs.contains(where: { $0.message == "first stream" })
+      {
         break
       }
       await Task.yield()
@@ -5407,7 +5410,8 @@ final class DashboardRuntimeStateTests: XCTestCase {
       model.runtimeData.flushPendingLogs()
       if model.trafficSample == TrafficSample(upload: 33, download: 44),
          model.logs.contains(where: { $0.message == "reconnected stream" }),
-         model.connections.map(\.id) == ["second"] {
+         model.connections.map(\.id) == ["second"]
+      {
         break
       }
       await Task.yield()
@@ -5433,7 +5437,8 @@ final class DashboardRuntimeStateTests: XCTestCase {
       if client.subscriptionCounts() == [1, 1, 1],
          client.connectionRequestCount() >= 1,
          !model.runtimeDataLoading,
-         model.runtimeSettingsApplyState == .idle {
+         model.runtimeSettingsApplyState == .idle
+      {
         break
       }
       await Task.yield()
@@ -5449,7 +5454,8 @@ final class DashboardRuntimeStateTests: XCTestCase {
          client.firstGenerationWasTerminated(),
          client.connectionRequestCount() >= 2,
          !model.runtimeDataLoading,
-         model.runtimeSettingsApplyState == .idle {
+         model.runtimeSettingsApplyState == .idle
+      {
         break
       }
       await Task.yield()
@@ -5472,7 +5478,8 @@ final class DashboardRuntimeStateTests: XCTestCase {
       model.runtimeData.flushPendingLogs()
       if model.trafficSample == TrafficSample(upload: 55, download: 66),
          model.logs.contains(where: { $0.message == "current generation" }),
-         model.connections.map(\.id) == ["current"] {
+         model.connections.map(\.id) == ["current"]
+      {
         break
       }
       await Task.yield()
@@ -5497,7 +5504,8 @@ final class DashboardRuntimeStateTests: XCTestCase {
       if !model.isCoreRunning,
          !model.systemProxyEnabled,
          !model.needsTerminationCleanup,
-         client.logAndConnectionWereTerminated(subscription: 1) {
+         client.logAndConnectionWereTerminated(subscription: 1)
+      {
         break
       }
       await Task.yield()
@@ -5573,7 +5581,8 @@ final class DashboardRuntimeStateTests: XCTestCase {
       if !paths.isEmpty,
          commandRunner.commands.contains("/usr/sbin/networksetup -setwebproxy Wi-Fi 127.0.0.1 17891"),
          model.settings.appliedRuntimeSettingsSnapshot?.overrides.mixedPort == 17_891,
-         model.runtimeSettingsApplyState == .idle {
+         model.runtimeSettingsApplyState == .idle
+      {
         break
       }
       await Task.yield()
@@ -5684,7 +5693,8 @@ final class DashboardRuntimeStateTests: XCTestCase {
     for _ in 0..<120 {
       let reloadPaths = await client.reloadRequestPaths()
       if !reloadPaths.isEmpty,
-         case .appliedWithFollowUpFailure = model.runtimeSettingsApplyState {
+         case .appliedWithFollowUpFailure = model.runtimeSettingsApplyState
+      {
         break
       }
       await Task.yield()
@@ -5928,12 +5938,12 @@ final class DashboardRuntimeStateTests: XCTestCase {
       nodes: [
         ProxyNode(name: "Japan", type: "vless", delay: nil, isSelectable: true),
         ProxyNode(name: "Hong Kong", type: "vless", delay: nil, isSelectable: true),
-        ProxyNode(name: "Singapore", type: "vless", delay: nil, isSelectable: true)
+        ProxyNode(name: "Singapore", type: "vless", delay: nil, isSelectable: true),
       ]
     )
     let client = RecordingMihomoController(
       proxyGroupsResponse: [
-        ProxyGroup(name: "Proxy", type: "select", selected: "Singapore", nodes: group.nodes)
+        ProxyGroup(name: "Proxy", type: "select", selected: "Singapore", nodes: group.nodes),
       ],
       testDelayResult: 73,
       selectProxyDelaysNanoseconds: [120_000_000, 10_000_000]
@@ -5959,7 +5969,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
       selected: "Japan",
       nodes: [
         ProxyNode(name: "Japan", type: "vless", delay: nil, isSelectable: true),
-        ProxyNode(name: "Singapore", type: "vless", delay: nil, isSelectable: true)
+        ProxyNode(name: "Singapore", type: "vless", delay: nil, isSelectable: true),
       ]
     )
     let staleConnection = ConnectionSnapshot(
@@ -5984,7 +5994,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
     )
     let client = RecordingMihomoController(
       proxyGroupsResponse: [
-        ProxyGroup(name: "Proxy", type: "select", selected: "Singapore", nodes: group.nodes)
+        ProxyGroup(name: "Proxy", type: "select", selected: "Singapore", nodes: group.nodes),
       ],
       connectionsResponse: [currentConnection],
       testDelayResult: 73
@@ -6019,7 +6029,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
       selected: "Japan",
       nodes: [
         ProxyNode(name: "Japan", type: "vless", delay: nil, isSelectable: true),
-        ProxyNode(name: "Singapore", type: "vless", delay: nil, isSelectable: true)
+        ProxyNode(name: "Singapore", type: "vless", delay: nil, isSelectable: true),
       ]
     )
     let client = RecordingMihomoController(proxyGroupsResponse: [group], testDelayResult: 73)
@@ -6041,12 +6051,12 @@ final class DashboardRuntimeStateTests: XCTestCase {
       selected: "Japan",
       nodes: [
         ProxyNode(name: "Japan", type: "vless", delay: nil, isSelectable: true),
-        ProxyNode(name: "DIRECT", type: "direct", delay: nil, isSelectable: true)
+        ProxyNode(name: "DIRECT", type: "direct", delay: nil, isSelectable: true),
       ]
     )
     let client = RecordingMihomoController(
       proxyGroupsResponse: [
-        ProxyGroup(name: "Proxy", type: "select", selected: "DIRECT", nodes: group.nodes)
+        ProxyGroup(name: "Proxy", type: "select", selected: "DIRECT", nodes: group.nodes),
       ],
       testDelayResult: 73
     )
@@ -6072,7 +6082,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
       selected: "Japan",
       nodes: [
         ProxyNode(name: "Japan", type: "vless", delay: nil, isSelectable: true),
-        ProxyNode(name: "DIRECT", type: "direct", delay: nil, isSelectable: true)
+        ProxyNode(name: "DIRECT", type: "direct", delay: nil, isSelectable: true),
       ]
     )
     let client = RecordingMihomoController(
@@ -6101,12 +6111,12 @@ final class DashboardRuntimeStateTests: XCTestCase {
       selected: "Japan",
       nodes: [
         ProxyNode(name: "Japan", type: "vless", delay: nil, isSelectable: true),
-        ProxyNode(name: "DIRECT", type: "direct", delay: nil, isSelectable: true)
+        ProxyNode(name: "DIRECT", type: "direct", delay: nil, isSelectable: true),
       ]
     )
     let client = RecordingMihomoController(
       proxyGroupsResponse: [
-        ProxyGroup(name: "Proxy", type: "select", selected: "DIRECT", nodes: group.nodes)
+        ProxyGroup(name: "Proxy", type: "select", selected: "DIRECT", nodes: group.nodes),
       ],
       testDelayResult: 73
     )
@@ -6255,7 +6265,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
       nodes: [
         ProxyNode(name: "Japan", type: "vless", delay: nil, isSelectable: true),
         ProxyNode(name: "Singapore", type: "vless", delay: nil, isSelectable: true),
-        ProxyNode(name: "Provider: remote", type: "provider", delay: nil, isSelectable: false)
+        ProxyNode(name: "Provider: remote", type: "provider", delay: nil, isSelectable: false),
       ]
     )
     let client = RecordingMihomoController(
@@ -6285,7 +6295,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
       nodes: [
         ProxyNode(name: "Japan", type: "vless", delay: nil, isSelectable: true),
         ProxyNode(name: "Singapore", type: "vless", delay: nil, isSelectable: true),
-        ProxyNode(name: "Provider: remote", type: "provider", delay: nil, isSelectable: false)
+        ProxyNode(name: "Provider: remote", type: "provider", delay: nil, isSelectable: false),
       ]
     )
     let groupB = ProxyGroup(
@@ -6293,7 +6303,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
       type: "select",
       selected: "US",
       nodes: [
-        ProxyNode(name: "US", type: "vless", delay: nil, isSelectable: true)
+        ProxyNode(name: "US", type: "vless", delay: nil, isSelectable: true),
       ]
     )
     let client = RecordingMihomoController(
@@ -6333,7 +6343,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
         ProxyNode(name: "Japan", type: "vless", delay: nil, isSelectable: true),
         ProxyNode(name: "Timeout", type: "vless", delay: nil, isSelectable: true),
         ProxyNode(name: "Controller", type: "vless", delay: nil, isSelectable: true),
-        ProxyNode(name: "Broken", type: "vless", delay: nil, isSelectable: true)
+        ProxyNode(name: "Broken", type: "vless", delay: nil, isSelectable: true),
       ]
     )
     let client = RecordingMihomoController(
@@ -6343,7 +6353,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
         nil,
         "request timed out",
         "Could not connect to the server.",
-        "provider failed"
+        "provider failed",
       ]
     )
     let model = try await makeRunningRuntimeModel(client: client, initialProxyGroups: [group])
@@ -6424,7 +6434,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
         ProxyNode(name: "REJECT-DROP", type: "RejectDrop", delay: nil, isSelectable: true),
         ProxyNode(name: "PASS", type: "Pass", delay: nil, isSelectable: true),
         ProxyNode(name: "COMPATIBLE", type: "Compatible", delay: nil, isSelectable: true),
-        ProxyNode(name: "Japan", type: "vless", delay: nil, isSelectable: true)
+        ProxyNode(name: "Japan", type: "vless", delay: nil, isSelectable: true),
       ]
     )
     let client = RecordingMihomoController(
@@ -6459,7 +6469,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
       selected: "REJECT",
       nodes: [
         ProxyNode(name: "REJECT", type: "Reject", delay: nil, isSelectable: true),
-        ProxyNode(name: "Japan", type: "vless", delay: nil, isSelectable: true)
+        ProxyNode(name: "Japan", type: "vless", delay: nil, isSelectable: true),
       ]
     )
     let client = RecordingMihomoController(proxyGroupsResponse: [group], testDelayResult: 73)
@@ -6488,7 +6498,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
       nodes: [
         ProxyNode(name: "Japan", type: "vless", delay: nil, isSelectable: true),
         ProxyNode(name: "PASS-RULE", type: "PassRule", delay: nil, isSelectable: true),
-        ProxyNode(name: "DIRECT", type: "Direct", delay: nil, isSelectable: true)
+        ProxyNode(name: "DIRECT", type: "Direct", delay: nil, isSelectable: true),
       ]
     )
     let client = RecordingMihomoController(
@@ -6551,7 +6561,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
         600_000_000,
         600_000_000,
         600_000_000,
-        600_000_000
+        600_000_000,
       ]
     )
     let model = try await makeRunningRuntimeModel(client: client, initialProxyGroups: [group])
@@ -6782,7 +6792,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
         600_000_000,
         600_000_000,
         600_000_000,
-        600_000_000
+        600_000_000,
       ]
     )
     let model = try await makeRunningRuntimeModel(client: client, initialProxyGroups: [group])
@@ -6811,7 +6821,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
       selected: "Japan",
       nodes: [
         ProxyNode(name: "Japan", type: "vless", delay: nil, isSelectable: true),
-        ProxyNode(name: "Singapore", type: "vless", delay: nil, isSelectable: true)
+        ProxyNode(name: "Singapore", type: "vless", delay: nil, isSelectable: true),
       ]
     )
     let client = RecordingMihomoController(
@@ -6970,7 +6980,8 @@ final class DashboardRuntimeStateTests: XCTestCase {
       let delayRequests = await client.delayRequestCount()
       let groupRequests = await client.proxyGroupsRequestCount()
       if delayRequests >= 1, groupRequests >= 1, !model.runtimeDataLoading,
-         model.proxyProviders.first?.proxies.first != nil {
+         model.proxyProviders.first?.proxies.first != nil
+      {
         break
       }
       await Task.yield()
@@ -7049,7 +7060,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
     for _ in 0..<80 {
       let proxyUpdates = await client.updatedProxyProviders()
       let ruleUpdates = await client.updatedRuleProviders()
-      if proxyUpdates == ["Remote/sub"] && ruleUpdates == ["Rules/sub"] {
+      if proxyUpdates == ["Remote/sub"], ruleUpdates == ["Rules/sub"] {
         break
       }
       await Task.yield()
@@ -7092,7 +7103,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
 
     for _ in 0..<120 {
       let updates = await client.updatedProxyProviders()
-      if updates.count == 1 && model.proxyProviderUpdatesInFlight.isEmpty {
+      if updates.count == 1, model.proxyProviderUpdatesInFlight.isEmpty {
         break
       }
       await Task.yield()
@@ -7185,7 +7196,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
 
     for _ in 0..<80 {
       let updates = await client.updatedProxyProviders()
-      if updates.count == 2 && model.lastError?.contains("Remote A: proxy update refused") == true {
+      if updates.count == 2, model.lastError?.contains("Remote A: proxy update refused") == true {
         break
       }
       await Task.yield()
@@ -7202,7 +7213,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
 
     for _ in 0..<80 {
       let updates = await client.updatedRuleProviders()
-      if updates.count == 2 && model.lastError?.contains("Rules A: rule update refused") == true {
+      if updates.count == 2, model.lastError?.contains("Rules A: rule update refused") == true {
         break
       }
       await Task.yield()
@@ -7262,7 +7273,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
       selected: "Japan",
       nodes: [
         ProxyNode(name: "Japan", type: "vless", delay: nil, isSelectable: true),
-        ProxyNode(name: "Singapore", type: "vless", delay: nil, isSelectable: true)
+        ProxyNode(name: "Singapore", type: "vless", delay: nil, isSelectable: true),
       ]
     )
     let refreshedGroup = ProxyGroup(
@@ -7287,7 +7298,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
 
     for _ in 0..<160 {
       let proxyGroupsRequestCount = await client.proxyGroupsRequestCount()
-      if proxyGroupsRequestCount == 2 && model.proxyGroups.first?.selected == "Singapore" {
+      if proxyGroupsRequestCount == 2, model.proxyGroups.first?.selected == "Singapore" {
         break
       }
       await Task.yield()
@@ -7383,9 +7394,10 @@ final class DashboardRuntimeStateTests: XCTestCase {
     for _ in 0..<40 {
       let healthCheckRequestCount = await client.healthCheckRequestCount()
       let closedConnectionIDs = await client.closedConnectionIDs()
-      if healthCheckRequestCount > 0
-        && model.proxyProviderUpdatesInFlight.contains(provider.id)
-        && !closedConnectionIDs.isEmpty {
+      if healthCheckRequestCount > 0,
+         model.proxyProviderUpdatesInFlight.contains(provider.id),
+         !closedConnectionIDs.isEmpty
+      {
         break
       }
       await Task.yield()
@@ -7421,10 +7433,10 @@ final class DashboardRuntimeStateTests: XCTestCase {
       url: URL(string: "https://example.com/sub")!,
       session: URLSession(configuration: URLProtocolRecorder.configurationReturning(originalSource))
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     let failureRecorder = URLProtocolRecorder(
       responseBody: "Forbidden",
@@ -7562,11 +7574,11 @@ final class DashboardRuntimeStateTests: XCTestCase {
       fingerprintProvider: StaticFingerprintProvider(fingerprint: "test"),
       registrationRecordStore: InMemoryHelperRegistrationRecordStore(storedFingerprint: "test")
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       helperClient: helper,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
 
     model.start()
@@ -7620,12 +7632,12 @@ final class DashboardRuntimeStateTests: XCTestCase {
       portChecker: EmptyRuntimePortChecker()
     )
     let commandRunner = RecordingCommandRunner(outputs: Self.defaultNetworkSetupOutputs())
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
       systemProxyController: SystemProxyController(commandRunner: commandRunner),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
 
     model.start()
@@ -7670,7 +7682,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
       systemExtensionRequester: StaticSystemExtensionRequester(activationState: .activated),
       transparentProxyManager: proxyManager
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
@@ -7678,7 +7690,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
       helperClient: helper,
       networkExtensionController: networkExtensionController,
       proxyPortReadinessProbe: proxyPortReadiness,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     XCTAssertTrue(
       model.updateNetworkExtensionRoutingSettings(
@@ -7725,7 +7737,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
       proxyPortReadiness.requests,
       [
         ProxyPortReadinessRequest(host: "127.0.0.1", port: 7890),
-        ProxyPortReadinessRequest(host: "127.0.0.1", port: 1053, serviceName: "Mihomo DNS")
+        ProxyPortReadinessRequest(host: "127.0.0.1", port: 1053, serviceName: "Mihomo DNS"),
       ]
     )
     XCTAssertTrue(commandRunner.commands.contains("/usr/sbin/networksetup -setdnsservers Wi-Fi 114.114.114.114"))
@@ -7763,7 +7775,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
     let commandRunner = RecordingCommandRunner(outputs: Self.defaultNetworkSetupOutputs())
     let systemProxyController = SystemProxyController(commandRunner: commandRunner)
     let proxyManager = RecordingTransparentProxyManager(startStatus: .connected)
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
@@ -7773,7 +7785,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
         transparentProxyManager: proxyManager
       ),
       proxyPortReadinessProbe: RecordingProxyPortReadinessProbe(),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.setProxyRoutingMode(.neProxy)
     model.start()
@@ -7795,7 +7807,8 @@ final class DashboardRuntimeStateTests: XCTestCase {
       let commands = commandRunner.commands
       let newCommands = commands.dropFirst(commandsBeforeRepair.count)
       if commands.filter({ $0 == "/usr/sbin/networksetup -setdnsservers Wi-Fi 114.114.114.114" }).count >= 2
-          || newCommands.contains("/usr/sbin/networksetup -setdnsservers Wi-Fi Empty") {
+        || newCommands.contains("/usr/sbin/networksetup -setdnsservers Wi-Fi Empty")
+      {
         break
       }
       await Task.yield()
@@ -7833,7 +7846,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
       portChecker: EmptyRuntimePortChecker()
     )
     let proxyManager = RecordingTransparentProxyManager(startStatus: .connected)
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
@@ -7843,7 +7856,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
         transparentProxyManager: proxyManager
       ),
       proxyPortReadinessProbe: RecordingProxyPortReadinessProbe(),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.setProxyRoutingMode(.neProxy)
     model.start()
@@ -7873,7 +7886,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
   func testUpdatingNetworkExtensionRoutingSettingsOutsideNetworkExtensionModeOnlyPersists() throws {
     let paths = try Self.makeRuntimePaths()
     let launcher = CountingProcessLauncher()
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
       coreController: CoreProcessController(
@@ -7883,7 +7896,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
         reaper: RecordingCoreProcessReaper(),
         portChecker: EmptyRuntimePortChecker()
       ),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
 
     XCTAssertTrue(
@@ -7900,7 +7913,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
   func testUpdatingNetworkExtensionRoutingSettingsRejectsInvalidCIDR() throws {
     let paths = try Self.makeRuntimePaths()
     let launcher = CountingProcessLauncher()
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
       coreController: CoreProcessController(
@@ -7910,7 +7923,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
         reaper: RecordingCoreProcessReaper(),
         portChecker: EmptyRuntimePortChecker()
       ),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
 
     XCTAssertFalse(
@@ -7927,7 +7940,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
   func testUpdatingNetworkExtensionRoutingSettingsRejectsInvalidDNSSettings() throws {
     let paths = try Self.makeRuntimePaths()
     let launcher = CountingProcessLauncher()
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
       coreController: CoreProcessController(
@@ -7937,7 +7950,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
         reaper: RecordingCoreProcessReaper(),
         portChecker: EmptyRuntimePortChecker()
       ),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
 
     XCTAssertFalse(
@@ -7979,14 +7992,14 @@ final class DashboardRuntimeStateTests: XCTestCase {
       transparentProxyManager: proxyManager,
       diagnosticsURL: diagnosticsURL
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
       systemProxyController: SystemProxyController(commandRunner: RecordingCommandRunner(outputs: Self.defaultNetworkSetupOutputs())),
       networkExtensionController: networkExtensionController,
       proxyPortReadinessProbe: RecordingProxyPortReadinessProbe(),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.setProxyRoutingMode(.neProxy)
     model.start()
@@ -8006,7 +8019,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
             id: "bypass-before-stop",
             message: "Bypassed self/core flow.",
             sourceAppSigningIdentifier: "io.github.clashmax.ClashMax"
-          )
+          ),
         ],
         recentErrors: [],
         updatedAt: Date()
@@ -8038,7 +8051,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
         bypassCount: 2,
         errorCount: 0,
         recentBypasses: [
-          NetworkExtensionDiagnosticEvent(id: "bypass-after-stop", message: "After stop bypass.")
+          NetworkExtensionDiagnosticEvent(id: "bypass-after-stop", message: "After stop bypass."),
         ],
         recentErrors: [],
         updatedAt: Date()
@@ -8065,17 +8078,17 @@ final class DashboardRuntimeStateTests: XCTestCase {
             isEnabled: true,
             isAwaitingUserApproval: false,
             isUninstalling: false
-          )
+          ),
         ]
       ),
       transparentProxyManager: proxyManager,
       diagnosticsURL: diagnosticsURL
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
       networkExtensionController: networkExtensionController,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     try Self.writeNetworkExtensionDiagnostics(
       NetworkExtensionDiagnosticsSnapshot(
@@ -8083,10 +8096,10 @@ final class DashboardRuntimeStateTests: XCTestCase {
         bypassCount: 1,
         errorCount: 1,
         recentBypasses: [
-          NetworkExtensionDiagnosticEvent(id: "manual-refresh-bypass", message: "Manual refresh bypass.")
+          NetworkExtensionDiagnosticEvent(id: "manual-refresh-bypass", message: "Manual refresh bypass."),
         ],
         recentErrors: [
-          NetworkExtensionDiagnosticEvent(id: "manual-refresh-error", message: "Manual refresh error.")
+          NetworkExtensionDiagnosticEvent(id: "manual-refresh-error", message: "Manual refresh error."),
         ],
         updatedAt: Date()
       ),
@@ -8127,7 +8140,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
     proxyManager.onStart = { events.append("networkExtensionStart") }
     let proxyPortReadiness = RecordingProxyPortReadinessProbe()
     proxyPortReadiness.onProbe = { events.append("proxyPortReady") }
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
@@ -8137,7 +8150,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
         transparentProxyManager: proxyManager
       ),
       proxyPortReadinessProbe: proxyPortReadiness,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.setProxyRoutingMode(.neProxy)
 
@@ -8153,7 +8166,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
       proxyPortReadiness.requests,
       [
         ProxyPortReadinessRequest(host: "127.0.0.1", port: 7890),
-        ProxyPortReadinessRequest(host: "127.0.0.1", port: 1053, serviceName: "Mihomo DNS")
+        ProxyPortReadinessRequest(host: "127.0.0.1", port: 1053, serviceName: "Mihomo DNS"),
       ]
     )
   }
@@ -8177,7 +8190,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
     let proxyPortReadiness = RecordingProxyPortReadinessProbe(
       result: .failure(AppError.coreNotReady("mixed-port refused"))
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
@@ -8187,7 +8200,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
         transparentProxyManager: proxyManager
       ),
       proxyPortReadinessProbe: proxyPortReadiness,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.setProxyRoutingMode(.neProxy)
 
@@ -8227,14 +8240,14 @@ final class DashboardRuntimeStateTests: XCTestCase {
       systemExtensionRequester: StaticSystemExtensionRequester(activationState: .activated),
       transparentProxyManager: proxyManager
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
       systemProxyController: SystemProxyController(commandRunner: commandRunner),
       networkExtensionController: networkExtensionController,
       proxyPortReadinessProbe: RecordingProxyPortReadinessProbe(),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.setProxyRoutingMode(.neProxy)
     model.start()
@@ -8271,7 +8284,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
       portChecker: EmptyRuntimePortChecker()
     )
     let proxyManager = RecordingTransparentProxyManager(startStatus: .connected)
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
@@ -8281,7 +8294,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
         transparentProxyManager: proxyManager
       ),
       proxyPortReadinessProbe: RecordingProxyPortReadinessProbe(),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.setProxyRoutingMode(.neProxy)
     model.start()
@@ -8341,7 +8354,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
     proxyManager.onStop = { events.append("networkExtensionStop") }
     let commandRunner = RecordingCommandRunner(outputs: Self.defaultNetworkSetupOutputs())
     let systemProxyController = SystemProxyController(commandRunner: commandRunner)
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
@@ -8351,7 +8364,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
         transparentProxyManager: proxyManager
       ),
       proxyPortReadinessProbe: RecordingProxyPortReadinessProbe(),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.setProxyRoutingMode(.neProxy)
     model.start()
@@ -8402,7 +8415,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
     proxyManager.onStop = { events.append("networkExtensionStop") }
     let commandRunner = RecordingCommandRunner(outputs: Self.defaultNetworkSetupOutputs())
     let systemProxyController = SystemProxyController(commandRunner: commandRunner)
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
@@ -8412,7 +8425,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
         transparentProxyManager: proxyManager
       ),
       proxyPortReadinessProbe: RecordingProxyPortReadinessProbe(),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.setProxyRoutingMode(.neProxy)
     model.start()
@@ -8465,7 +8478,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
     proxyManager.onStop = { events.append("networkExtensionStop") }
     let publicIPInfo = Self.makePublicIPInfo(ip: "203.0.113.9", fetchedAt: Date(timeIntervalSince1970: 1_000))
     let publicIPFetcher = RecordingPublicIPInfoFetcher(infos: [publicIPInfo], delayNanoseconds: 800_000_000)
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
@@ -8476,7 +8489,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
       ),
       proxyPortReadinessProbe: RecordingProxyPortReadinessProbe(),
       publicIPInfoClient: publicIPFetcher,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.setProxyRoutingMode(.neProxy)
     model.start()
@@ -8516,7 +8529,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
     )
     let proxyManager = RecordingTransparentProxyManager(startStatus: .connected, stopStatus: .disconnecting)
     proxyManager.onStop = { events.append("networkExtensionStop") }
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
@@ -8526,7 +8539,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
         transparentProxyManager: proxyManager
       ),
       proxyPortReadinessProbe: RecordingProxyPortReadinessProbe(),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.setProxyRoutingMode(.neProxy)
     model.start()
@@ -8565,7 +8578,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
     let proxyManager = RecordingTransparentProxyManager(startStatus: .connected)
     proxyManager.stopError = AppError.coreNotReady("transparent proxy stop refused")
     proxyManager.onStop = { events.append("networkExtensionStop") }
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
@@ -8575,7 +8588,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
         transparentProxyManager: proxyManager
       ),
       proxyPortReadinessProbe: RecordingProxyPortReadinessProbe(),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.setProxyRoutingMode(.neProxy)
     model.start()
@@ -8614,14 +8627,14 @@ final class DashboardRuntimeStateTests: XCTestCase {
       systemExtensionRequester: StaticSystemExtensionRequester(activationState: .activated),
       transparentProxyManager: proxyManager
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
       systemProxyController: SystemProxyController(commandRunner: RecordingCommandRunner(outputs: Self.defaultNetworkSetupOutputs())),
       networkExtensionController: networkExtensionController,
       proxyPortReadinessProbe: RecordingProxyPortReadinessProbe(),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.setProxyRoutingMode(.neProxy)
     model.start()
@@ -8660,14 +8673,14 @@ final class DashboardRuntimeStateTests: XCTestCase {
       systemExtensionRequester: StaticSystemExtensionRequester(activationState: .activated),
       transparentProxyManager: proxyManager
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
       systemProxyController: SystemProxyController(commandRunner: RecordingCommandRunner(outputs: Self.defaultNetworkSetupOutputs())),
       networkExtensionController: networkExtensionController,
       proxyPortReadinessProbe: RecordingProxyPortReadinessProbe(),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.setProxyRoutingMode(.neProxy)
     model.start()
@@ -8686,10 +8699,10 @@ final class DashboardRuntimeStateTests: XCTestCase {
 
   func testProxyRoutingModesIncludeNEProxyWhenDeveloperModeIsOff() throws {
     let paths = try Self.makeRuntimePaths()
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
 
     XCTAssertFalse(model.developerMode)
@@ -8699,8 +8712,8 @@ final class DashboardRuntimeStateTests: XCTestCase {
 
   func testNetworkExtensionLegacyPersistedModeLoadsWhenDeveloperModeIsOff() throws {
     let defaults = try Self.makeIsolatedDefaults()
-    defaults.set(
-      try XCTUnwrap("\"networkExtensionExperimental\"".data(using: .utf8)),
+    try defaults.set(
+      XCTUnwrap("\"networkExtensionExperimental\"".data(using: .utf8)),
       forKey: Self.proxyRoutingModeDefaultsKey
     )
     let paths = try Self.makeRuntimePaths()
@@ -8723,10 +8736,10 @@ final class DashboardRuntimeStateTests: XCTestCase {
 
   func testNetworkExtensionCanBeSelectedWhenDeveloperModeIsOff() throws {
     let paths = try Self.makeRuntimePaths()
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
 
     XCTAssertFalse(model.developerMode)
@@ -8739,10 +8752,10 @@ final class DashboardRuntimeStateTests: XCTestCase {
 
   func testDisablingDeveloperModeKeepsNetworkExtensionSelected() throws {
     let paths = try Self.makeRuntimePaths()
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
 
     model.developerMode = true
@@ -8757,16 +8770,16 @@ final class DashboardRuntimeStateTests: XCTestCase {
   func testDeveloperModeOffPreventsGlobalShortcutRegistration() throws {
     let paths = try Self.makeRuntimePaths()
     let registrar = RecordingAppGlobalShortcutRegistrar()
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
-      defaults: try Self.makeIsolatedDefaults(),
+      defaults: Self.makeIsolatedDefaults(),
       globalShortcutRegistrar: registrar
     )
     let shortcut = try XCTUnwrap(KeyboardShortcutDescriptor(string: "cmd+shift+p"))
 
     model.globalShortcutSettings = GlobalShortcutSettings(bindings: [
-      GlobalShortcutBinding(action: .startStop, shortcut: shortcut, enabled: true)
+      GlobalShortcutBinding(action: .startStop, shortcut: shortcut, enabled: true),
     ])
 
     XCTAssertFalse(model.developerMode)
@@ -8778,16 +8791,16 @@ final class DashboardRuntimeStateTests: XCTestCase {
   func testDeveloperModeToggleRegistersAndUnregistersGlobalShortcuts() throws {
     let paths = try Self.makeRuntimePaths()
     let registrar = RecordingAppGlobalShortcutRegistrar()
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
-      defaults: try Self.makeIsolatedDefaults(),
+      defaults: Self.makeIsolatedDefaults(),
       globalShortcutRegistrar: registrar
     )
     let shortcut = try XCTUnwrap(KeyboardShortcutDescriptor(string: "cmd+shift+p"))
 
     model.globalShortcutSettings = GlobalShortcutSettings(bindings: [
-      GlobalShortcutBinding(action: .startStop, shortcut: shortcut, enabled: true)
+      GlobalShortcutBinding(action: .startStop, shortcut: shortcut, enabled: true),
     ])
     model.setDeveloperMode(true)
 
@@ -8810,16 +8823,16 @@ final class DashboardRuntimeStateTests: XCTestCase {
       reason: "taken by the system"
     )
     let registrar = RecordingAppGlobalShortcutRegistrar(failuresToReturn: [failure])
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
-      defaults: try Self.makeIsolatedDefaults(),
+      defaults: Self.makeIsolatedDefaults(),
       globalShortcutRegistrar: registrar
     )
 
     model.setDeveloperMode(true)
     model.globalShortcutSettings = GlobalShortcutSettings(bindings: [
-      GlobalShortcutBinding(action: .startStop, shortcut: shortcut, enabled: true)
+      GlobalShortcutBinding(action: .startStop, shortcut: shortcut, enabled: true),
     ])
 
     XCTAssertEqual(model.shortcutRegistrationStatus?.failures, [failure])
@@ -8836,7 +8849,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
     let seed = PersistedSettingsStore(defaults: defaults)
     seed.developerMode = true
     seed.globalShortcutSettings = GlobalShortcutSettings(bindings: [
-      GlobalShortcutBinding(action: .startStop, shortcut: shortcut, enabled: true)
+      GlobalShortcutBinding(action: .startStop, shortcut: shortcut, enabled: true),
     ])
 
     let registrar = RecordingAppGlobalShortcutRegistrar()
@@ -8857,7 +8870,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
   }
 
   func testSubscriptionFetchSettingsHookObservesTheNewValue() throws {
-    let store = PersistedSettingsStore(defaults: try Self.makeIsolatedDefaults())
+    let store = try PersistedSettingsStore(defaults: Self.makeIsolatedDefaults())
 
     // The real handler takes no parameter and re-reads the store, exactly like
     // ProfileCoordinator.rescheduleSubscriptionAutoUpdates does.
@@ -8881,14 +8894,14 @@ final class DashboardRuntimeStateTests: XCTestCase {
     let paths = try Self.makeRuntimePaths()
     let requester = StaticSystemExtensionRequester(activationState: .requiresApproval)
     let proxyManager = RecordingTransparentProxyManager(currentStatus: .notConfigured)
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
       networkExtensionController: NetworkExtensionController(
         systemExtensionRequester: requester,
         transparentProxyManager: proxyManager
       ),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
 
     model.installNetworkExtension()
@@ -8903,7 +8916,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
         isEnabled: true,
         isAwaitingUserApproval: false,
         isUninstalling: false
-      )
+      ),
     ]
     model.refreshNetworkExtensionStatus()
     for _ in 0..<60 where model.lastError != nil {
@@ -8924,18 +8937,18 @@ final class DashboardRuntimeStateTests: XCTestCase {
           isEnabled: true,
           isAwaitingUserApproval: false,
           isUninstalling: false
-        )
+        ),
       ]
     )
     let proxyManager = RecordingTransparentProxyManager(currentStatus: .notConfigured)
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
       networkExtensionController: NetworkExtensionController(
         systemExtensionRequester: requester,
         transparentProxyManager: proxyManager
       ),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.lastError = "Non-NE validation failed."
 
@@ -9004,14 +9017,14 @@ final class DashboardRuntimeStateTests: XCTestCase {
       fingerprintProvider: StaticFingerprintProvider(fingerprint: "test"),
       registrationRecordStore: InMemoryHelperRegistrationRecordStore(storedFingerprint: "test")
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       systemProxyController: SystemProxyController(commandRunner: RecordingCommandRunner(outputs: Self.defaultNetworkSetupOutputs())),
       helperClient: helper,
       tunnelReadinessProbe: RecordingCoreReadinessProbe(),
       tunRuntimeInspector: RecordingTunRuntimeInspector(snapshots: [.empty]),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.requestProxyRoutingMode(.tun)
     for _ in 0..<40 where !model.tunHelperPreparationState.isReady {
@@ -9058,14 +9071,14 @@ final class DashboardRuntimeStateTests: XCTestCase {
       fingerprintProvider: StaticFingerprintProvider(fingerprint: "test"),
       registrationRecordStore: InMemoryHelperRegistrationRecordStore(storedFingerprint: "test")
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       systemProxyController: SystemProxyController(commandRunner: RecordingCommandRunner(outputs: Self.defaultNetworkSetupOutputs())),
       helperClient: helper,
       tunnelReadinessProbe: RecordingCoreReadinessProbe(),
       tunRuntimeInspector: RecordingTunRuntimeInspector(snapshots: [.empty]),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.requestProxyRoutingMode(.tun)
     for _ in 0..<40 where !model.tunHelperPreparationState.isReady {
@@ -9118,13 +9131,13 @@ final class DashboardRuntimeStateTests: XCTestCase {
       registrationRecordStore: InMemoryHelperRegistrationRecordStore(storedFingerprint: "test")
     )
     let commandRunner = RecordingCommandRunner(outputs: Self.defaultNetworkSetupOutputs())
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       systemProxyController: SystemProxyController(commandRunner: commandRunner),
       helperClient: helper,
       tunnelReadinessProbe: RecordingCoreReadinessProbe(),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.requestProxyRoutingMode(.tun)
     for _ in 0..<40 where !model.tunHelperPreparationState.isReady {
@@ -9170,13 +9183,13 @@ final class DashboardRuntimeStateTests: XCTestCase {
       registrationRecordStore: InMemoryHelperRegistrationRecordStore(storedFingerprint: "test")
     )
     let commandRunner = FailingDNSApplyCommandRunner(outputs: Self.defaultNetworkSetupOutputs())
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       systemProxyController: SystemProxyController(commandRunner: commandRunner),
       helperClient: helper,
       tunnelReadinessProbe: RecordingCoreReadinessProbe(),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.requestProxyRoutingMode(.tun)
     for _ in 0..<40 where !model.tunHelperPreparationState.isReady {
@@ -9214,21 +9227,21 @@ final class DashboardRuntimeStateTests: XCTestCase {
     let snapshot = Self.tunDiagnosticsSnapshot(
       checks: [
         TunDiagnosticCheck(id: "controller", title: "Controller", status: .pass, message: "ready"),
-        TunDiagnosticCheck(id: "system-dns", title: "System DNS", status: .pass, message: "applied")
+        TunDiagnosticCheck(id: "system-dns", title: "System DNS", status: .pass, message: "applied"),
       ],
       includeExternal: true,
       time: 1
     )
     let inspector = RecordingTunRuntimeInspector(snapshots: [snapshot])
     let commandRunner = RecordingCommandRunner(outputs: Self.defaultNetworkSetupOutputs())
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       systemProxyController: SystemProxyController(commandRunner: commandRunner),
       helperClient: helper,
       tunnelReadinessProbe: RecordingCoreReadinessProbe(),
       tunRuntimeInspector: inspector,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.requestProxyRoutingMode(.tun)
     for _ in 0..<40 where !model.tunHelperPreparationState.isReady {
@@ -9270,20 +9283,20 @@ final class DashboardRuntimeStateTests: XCTestCase {
           title: "TUN Interface",
           status: .fail,
           message: "No utun interface was found."
-        )
+        ),
       ],
       includeExternal: true,
       time: 2
     )
     let inspector = RecordingTunRuntimeInspector(snapshots: [snapshot])
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       systemProxyController: SystemProxyController(commandRunner: RecordingCommandRunner(outputs: Self.defaultNetworkSetupOutputs())),
       helperClient: helper,
       tunnelReadinessProbe: RecordingCoreReadinessProbe(),
       tunRuntimeInspector: inspector,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.requestProxyRoutingMode(.tun)
     for _ in 0..<40 where !model.tunHelperPreparationState.isReady {
@@ -9326,14 +9339,14 @@ final class DashboardRuntimeStateTests: XCTestCase {
       time: 4
     )
     let inspector = RecordingTunRuntimeInspector(snapshots: [first, second])
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       systemProxyController: SystemProxyController(commandRunner: RecordingCommandRunner(outputs: Self.defaultNetworkSetupOutputs())),
       helperClient: helper,
       tunnelReadinessProbe: RecordingCoreReadinessProbe(),
       tunRuntimeInspector: inspector,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.requestProxyRoutingMode(.tun)
     for _ in 0..<40 where !model.tunHelperPreparationState.isReady {
@@ -9374,14 +9387,14 @@ final class DashboardRuntimeStateTests: XCTestCase {
       time: 41
     )
     let inspector = RecordingTunRuntimeInspector(snapshots: [snapshot])
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       systemProxyController: SystemProxyController(commandRunner: RecordingCommandRunner(outputs: Self.defaultNetworkSetupOutputs())),
       helperClient: helper,
       tunnelReadinessProbe: RecordingCoreReadinessProbe(),
       tunRuntimeInspector: inspector,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.requestProxyRoutingMode(.tun)
     for _ in 0..<40 where !model.tunHelperPreparationState.isReady {
@@ -9448,7 +9461,8 @@ final class DashboardRuntimeStateTests: XCTestCase {
     // config and after tunSystemDNSState is already .applied).
     for _ in 0..<500 where commandRunner.commands.filter({ $0 == applyCommand }).count <= initialApplyCount
       || model.tunSystemDNSState != .applied(serviceCount: 1)
-      || model.tunDiagnostics != repaired {
+      || model.tunDiagnostics != repaired
+    {
       await Task.yield()
       try? await Task.sleep(nanoseconds: 1_000_000)
     }
@@ -9521,7 +9535,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
           title: "TUN Route",
           status: .warn,
           message: "Route to 1.1.1.1 is not using the configured TUN device."
-        )
+        ),
       ],
       includeExternal: false,
       time: 11
@@ -9533,7 +9547,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
           title: "TUN Route",
           status: .info,
           message: "Route to 1.1.1.1 is not using the configured TUN device. Live TCP and UDP probes still reached the network, so traffic is flowing."
-        )
+        ),
       ],
       includeExternal: true,
       time: 12
@@ -9743,7 +9757,8 @@ final class DashboardRuntimeStateTests: XCTestCase {
       if currentRestartCount == 1,
          loggedFallback,
          loggedSuccess,
-         model.runtimeSettingsApplyState == .idle {
+         model.runtimeSettingsApplyState == .idle
+      {
         break
       }
       await Task.yield()
@@ -9787,7 +9802,8 @@ final class DashboardRuntimeStateTests: XCTestCase {
     for _ in 0..<240 {
       if !model.tunnelCoreRunning,
          !model.tunEnabled,
-         model.lastError?.contains("stopped TUN safely") == true {
+         model.lastError?.contains("stopped TUN safely") == true
+      {
         break
       }
       await Task.yield()
@@ -9810,7 +9826,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
     let routeIssue = Self.tunDiagnosticsSnapshot(
       checks: [
         Self.nonRoutingControllerFailureCheck(),
-        TunDiagnosticCheck(id: "default-route", title: "Default Route", status: .fail, message: "stale")
+        TunDiagnosticCheck(id: "default-route", title: "Default Route", status: .fail, message: "stale"),
       ],
       includeExternal: false,
       time: 44
@@ -9853,7 +9869,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
     let routeIssue = Self.tunDiagnosticsSnapshot(
       checks: [
         Self.nonRoutingControllerFailureCheck(),
-        TunDiagnosticCheck(id: "default-route", title: "Default Route", status: .fail, message: "stale")
+        TunDiagnosticCheck(id: "default-route", title: "Default Route", status: .fail, message: "stale"),
       ],
       includeExternal: false,
       time: 46
@@ -9876,7 +9892,8 @@ final class DashboardRuntimeStateTests: XCTestCase {
     for _ in 0..<240 {
       if !model.tunnelCoreRunning,
          !model.tunEnabled,
-         model.lastError?.contains("stopped TUN safely") == true {
+         model.lastError?.contains("stopped TUN safely") == true
+      {
         break
       }
       await Task.yield()
@@ -9957,7 +9974,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
     let routeIssue = Self.tunDiagnosticsSnapshot(
       checks: [
         Self.nonRoutingControllerFailureCheck(),
-        TunDiagnosticCheck(id: "default-route", title: "Default Route", status: .fail, message: "stale")
+        TunDiagnosticCheck(id: "default-route", title: "Default Route", status: .fail, message: "stale"),
       ],
       includeExternal: false,
       time: 57
@@ -10017,7 +10034,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
     let routeIssue = Self.tunDiagnosticsSnapshot(
       checks: [
         Self.nonRoutingControllerFailureCheck(),
-        TunDiagnosticCheck(id: "default-route", title: "Default Route", status: .fail, message: "stale")
+        TunDiagnosticCheck(id: "default-route", title: "Default Route", status: .fail, message: "stale"),
       ],
       includeExternal: false,
       time: 52
@@ -10058,7 +10075,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
     let routeIssue = Self.tunDiagnosticsSnapshot(
       checks: [
         Self.nonRoutingControllerFailureCheck(),
-        TunDiagnosticCheck(id: "default-route", title: "Default Route", status: .fail, message: "stale")
+        TunDiagnosticCheck(id: "default-route", title: "Default Route", status: .fail, message: "stale"),
       ],
       includeExternal: false,
       time: 54
@@ -10080,7 +10097,8 @@ final class DashboardRuntimeStateTests: XCTestCase {
       if !model.tunnelCoreRunning,
          !model.tunEnabled,
          model.tunDiagnostics == .empty,
-         model.lastError?.contains("stopped TUN safely") == true {
+         model.lastError?.contains("stopped TUN safely") == true
+      {
         break
       }
       await Task.yield()
@@ -10109,7 +10127,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
     let routeIssue = Self.tunDiagnosticsSnapshot(
       checks: [
         Self.nonRoutingControllerFailureCheck(),
-        TunDiagnosticCheck(id: "default-route", title: "Default Route", status: .fail, message: "stale")
+        TunDiagnosticCheck(id: "default-route", title: "Default Route", status: .fail, message: "stale"),
       ],
       includeExternal: false,
       time: 56
@@ -10126,7 +10144,8 @@ final class DashboardRuntimeStateTests: XCTestCase {
       if !model.tunnelCoreRunning,
          !model.tunEnabled,
          model.tunDiagnostics == .empty,
-         model.lastError?.contains("stopped TUN safely") == true {
+         model.lastError?.contains("stopped TUN safely") == true
+      {
         break
       }
       await Task.yield()
@@ -10159,7 +10178,8 @@ final class DashboardRuntimeStateTests: XCTestCase {
       if !model.tunnelCoreRunning,
          !model.tunEnabled,
          model.tunDiagnostics == .empty,
-         model.lastError?.contains("stopped TUN safely") == true {
+         model.lastError?.contains("stopped TUN safely") == true
+      {
         break
       }
       await Task.yield()
@@ -10194,14 +10214,14 @@ final class DashboardRuntimeStateTests: XCTestCase {
       time: 7
     )
     let commandRunner = RecordingCommandRunner(outputs: Self.defaultNetworkSetupOutputs())
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       systemProxyController: SystemProxyController(commandRunner: commandRunner),
       helperClient: helper,
       tunnelReadinessProbe: RecordingCoreReadinessProbe(),
       tunRuntimeInspector: RecordingTunRuntimeInspector(snapshots: [snapshot]),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.requestProxyRoutingMode(.tun)
     for _ in 0..<40 where !model.tunHelperPreparationState.isReady {
@@ -10242,12 +10262,12 @@ final class DashboardRuntimeStateTests: XCTestCase {
       reaper: RecordingCoreProcessReaper(),
       portChecker: EmptyRuntimePortChecker()
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
       systemProxyController: SystemProxyController(commandRunner: RecordingCommandRunner(outputs: Self.defaultNetworkSetupOutputs())),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
 
     model.start()
@@ -10286,12 +10306,12 @@ final class DashboardRuntimeStateTests: XCTestCase {
       reaper: RecordingCoreProcessReaper(),
       portChecker: EmptyRuntimePortChecker()
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
       systemProxyController: SystemProxyController(commandRunner: RecordingCommandRunner(outputs: Self.defaultNetworkSetupOutputs())),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
 
     model.start()
@@ -10330,12 +10350,12 @@ final class DashboardRuntimeStateTests: XCTestCase {
       reaper: RecordingCoreProcessReaper(),
       portChecker: EmptyRuntimePortChecker()
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       coreController: controller,
       systemProxyController: SystemProxyController(commandRunner: RecordingCommandRunner(outputs: Self.defaultNetworkSetupOutputs())),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
 
     model.start()
@@ -10362,10 +10382,10 @@ final class DashboardRuntimeStateTests: XCTestCase {
 
   func testSettingCurrentModeDoesNotPublishChanges() throws {
     let paths = try Self.makeRuntimePaths()
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     let counter = ObservationChangeCounter { _ = model.overrides }
 
@@ -10376,10 +10396,10 @@ final class DashboardRuntimeStateTests: XCTestCase {
 
   func testRequestingModeDefersPublishedChangesUntilNextActorTurn() async throws {
     let paths = try Self.makeRuntimePaths()
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     let counter = ObservationChangeCounter { _ = model.overrides }
 
@@ -10466,11 +10486,11 @@ final class DashboardRuntimeStateTests: XCTestCase {
       fingerprintProvider: StaticFingerprintProvider(fingerprint: "test"),
       registrationRecordStore: InMemoryHelperRegistrationRecordStore(storedFingerprint: nil)
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       helperClient: helper,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
 
     model.requestProxyRoutingMode(.tun)
@@ -10506,11 +10526,11 @@ final class DashboardRuntimeStateTests: XCTestCase {
       fingerprintProvider: StaticFingerprintProvider(fingerprint: "test"),
       registrationRecordStore: InMemoryHelperRegistrationRecordStore(storedFingerprint: nil)
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
       helperClient: helper,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
 
     model.warmTunHelperRegistrationOnLaunch()
@@ -10552,11 +10572,11 @@ final class DashboardRuntimeStateTests: XCTestCase {
       fingerprintProvider: StaticFingerprintProvider(fingerprint: "test"),
       registrationRecordStore: InMemoryHelperRegistrationRecordStore(storedFingerprint: nil)
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
       helperClient: helper,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.proxyRoutingMode = .tun
 
@@ -10578,11 +10598,11 @@ final class DashboardRuntimeStateTests: XCTestCase {
       fingerprintProvider: StaticFingerprintProvider(fingerprint: "test"),
       registrationRecordStore: InMemoryHelperRegistrationRecordStore(storedFingerprint: nil)
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
       helperClient: helper,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     XCTAssertEqual(model.proxyRoutingMode, .systemProxy)
 
@@ -10704,11 +10724,11 @@ final class DashboardRuntimeStateTests: XCTestCase {
       fingerprintProvider: StaticFingerprintProvider(fingerprint: "test"),
       registrationRecordStore: InMemoryHelperRegistrationRecordStore(storedFingerprint: nil)
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
       helperClient: helper,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.proxyRoutingMode = .tun
 
@@ -10736,11 +10756,11 @@ final class DashboardRuntimeStateTests: XCTestCase {
       fingerprintProvider: StaticFingerprintProvider(fingerprint: "test"),
       registrationRecordStore: InMemoryHelperRegistrationRecordStore(storedFingerprint: nil)
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
       helperClient: helper,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
 
     model.warmTunHelperRegistrationOnLaunch()
@@ -10775,11 +10795,11 @@ final class DashboardRuntimeStateTests: XCTestCase {
       fingerprintProvider: StaticFingerprintProvider(fingerprint: "test"),
       registrationRecordStore: InMemoryHelperRegistrationRecordStore(storedFingerprint: "test")
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
       helperClient: helper,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
 
     model.warmTunHelperRegistrationOnLaunch()
@@ -10798,11 +10818,11 @@ final class DashboardRuntimeStateTests: XCTestCase {
       fingerprintProvider: StaticFingerprintProvider(fingerprint: "test"),
       registrationRecordStore: InMemoryHelperRegistrationRecordStore(storedFingerprint: "test")
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
       helperClient: helper,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.proxyRoutingMode = .tun
 
@@ -10829,11 +10849,11 @@ final class DashboardRuntimeStateTests: XCTestCase {
       fingerprintProvider: StaticFingerprintProvider(fingerprint: "test"),
       registrationRecordStore: InMemoryHelperRegistrationRecordStore(storedFingerprint: "test")
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
       helperClient: helper,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.proxyRoutingMode = .tun
 
@@ -10861,12 +10881,12 @@ final class DashboardRuntimeStateTests: XCTestCase {
       fingerprintProvider: StaticFingerprintProvider(fingerprint: "test"),
       registrationRecordStore: InMemoryHelperRegistrationRecordStore(storedFingerprint: nil)
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
       helperClient: helper,
       installLocationInspector: StubInstallLocationInspector(issue: .outsideApplications(folderName: "Downloads")),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.proxyRoutingMode = .tun
 
@@ -10888,12 +10908,12 @@ final class DashboardRuntimeStateTests: XCTestCase {
       fingerprintProvider: StaticFingerprintProvider(fingerprint: "test"),
       registrationRecordStore: InMemoryHelperRegistrationRecordStore(storedFingerprint: "test")
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
       helperClient: helper,
       installLocationInspector: StubInstallLocationInspector(issue: .translocated),
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.proxyRoutingMode = .tun
 
@@ -10912,11 +10932,11 @@ final class DashboardRuntimeStateTests: XCTestCase {
       fingerprintProvider: StaticFingerprintProvider(fingerprint: "test"),
       registrationRecordStore: InMemoryHelperRegistrationRecordStore(storedFingerprint: nil)
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
       helperClient: helper,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.proxyRoutingMode = .tun
 
@@ -10953,11 +10973,11 @@ final class DashboardRuntimeStateTests: XCTestCase {
       fingerprintProvider: StaticFingerprintProvider(fingerprint: "test"),
       registrationRecordStore: InMemoryHelperRegistrationRecordStore(storedFingerprint: nil)
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
       helperClient: helper,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
 
     model.warmTunHelperRegistrationOnLaunch()
@@ -10976,11 +10996,11 @@ final class DashboardRuntimeStateTests: XCTestCase {
       fingerprintProvider: StaticFingerprintProvider(fingerprint: "test"),
       registrationRecordStore: InMemoryHelperRegistrationRecordStore(storedFingerprint: nil)
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
       helperClient: helper,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.proxyRoutingMode = .tun
 
@@ -11009,11 +11029,11 @@ final class DashboardRuntimeStateTests: XCTestCase {
       fingerprintProvider: StaticFingerprintProvider(fingerprint: "test"),
       registrationRecordStore: InMemoryHelperRegistrationRecordStore(storedFingerprint: nil)
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
       helperClient: helper,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.proxyRoutingMode = .tun
 
@@ -11041,11 +11061,11 @@ final class DashboardRuntimeStateTests: XCTestCase {
       fingerprintProvider: StaticFingerprintProvider(fingerprint: "test"),
       registrationRecordStore: InMemoryHelperRegistrationRecordStore(storedFingerprint: "test")
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: ProfileStore(paths: paths, keychain: InMemorySecretStore()),
       helperClient: helper,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
     model.proxyRoutingMode = .tun
 
@@ -11077,11 +11097,11 @@ final class DashboardRuntimeStateTests: XCTestCase {
       fingerprintProvider: StaticFingerprintProvider(fingerprint: "test"),
       registrationRecordStore: InMemoryHelperRegistrationRecordStore(storedFingerprint: "test")
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       helperClient: helper,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
 
     model.requestProxyRoutingMode(.tun)
@@ -11116,11 +11136,11 @@ final class DashboardRuntimeStateTests: XCTestCase {
       fingerprintProvider: StaticFingerprintProvider(fingerprint: "test"),
       registrationRecordStore: InMemoryHelperRegistrationRecordStore(storedFingerprint: nil)
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       helperClient: helper,
-      defaults: try Self.makeIsolatedDefaults()
+      defaults: Self.makeIsolatedDefaults()
     )
 
     model.requestProxyRoutingMode(.tun)
@@ -11220,7 +11240,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
       code: NSURLErrorCannotConnectToHost,
       userInfo: [
         NSLocalizedDescriptionKey: "Could not connect to the server.",
-        NSURLErrorFailingURLErrorKey: URL(string: "http://127.0.0.1:9097/version")!
+        NSURLErrorFailingURLErrorKey: URL(string: "http://127.0.0.1:9097/version")!,
       ]
     )
 
@@ -11235,7 +11255,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
       domain: "SMAppServiceErrorDomain",
       code: 3,
       userInfo: [
-        NSLocalizedDescriptionKey: "Codesigning failure loading plist: io.github.clashmax.ClashMax.Helper.plist code: -67056"
+        NSLocalizedDescriptionKey: "Codesigning failure loading plist: io.github.clashmax.ClashMax.Helper.plist code: -67056",
       ]
     )
 
@@ -11250,7 +11270,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
       domain: "SMAppServiceErrorDomain",
       code: 1,
       userInfo: [
-        NSLocalizedDescriptionKey: "Operation not permitted"
+        NSLocalizedDescriptionKey: "Operation not permitted",
       ]
     )
 
@@ -11277,10 +11297,10 @@ final class DashboardRuntimeStateTests: XCTestCase {
       in: paths.appSupport,
       rejectedToken: "bad-preflight.example"
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
-      defaults: try Self.makeIsolatedDefaults(),
+      defaults: Self.makeIsolatedDefaults(),
       bundledCoreURLProvider: { rejectingCore }
     )
     let snippet = RuntimeSnippet(
@@ -11291,7 +11311,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
         RuleOverlaySettings(
           enabled: true,
           prependRules: [
-            ManagedRuleOverlayRule(kind: .domainSuffix, value: "bad-preflight.example", policy: "DIRECT")
+            ManagedRuleOverlayRule(kind: .domainSuffix, value: "bad-preflight.example", policy: "DIRECT"),
           ]
         )
       )
@@ -11311,10 +11331,10 @@ final class DashboardRuntimeStateTests: XCTestCase {
     let store = ProfileStore(paths: paths, keychain: InMemorySecretStore())
     _ = try await store.importLocalConfig(from: configURL)
     let passingCore = try Self.makeRuleOverlayPreflightCore(in: paths.appSupport, rejectedToken: "never-matched")
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
-      defaults: try Self.makeIsolatedDefaults(),
+      defaults: Self.makeIsolatedDefaults(),
       bundledCoreURLProvider: { passingCore }
     )
     let draftSnippet = RuntimeSnippet(
@@ -11325,7 +11345,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
         RuleOverlaySettings(
           enabled: true,
           appendRules: [
-            ManagedRuleOverlayRule(kind: .domainSuffix, value: "draft-only.example", policy: "DIRECT")
+            ManagedRuleOverlayRule(kind: .domainSuffix, value: "draft-only.example", policy: "DIRECT"),
           ]
         )
       )
@@ -11350,10 +11370,10 @@ final class DashboardRuntimeStateTests: XCTestCase {
     let firstProfile = try await store.importLocalConfig(from: firstConfigURL)
     let secondProfile = try await store.importLocalConfig(from: secondConfigURL)
     try await store.select(firstProfile)
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
-      defaults: try Self.makeIsolatedDefaults(),
+      defaults: Self.makeIsolatedDefaults(),
       bundledCoreURLProvider: { throw AppError.missingBundledCore }
     )
 
@@ -11379,10 +11399,10 @@ final class DashboardRuntimeStateTests: XCTestCase {
     try Self.writeProxyConfig(named: "Japan", to: configURL)
     let store = ProfileStore(paths: paths, keychain: InMemorySecretStore())
     let profile = try await store.importLocalConfig(from: configURL)
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
-      defaults: try Self.makeIsolatedDefaults(),
+      defaults: Self.makeIsolatedDefaults(),
       bundledCoreURLProvider: { throw AppError.missingBundledCore }
     )
 
@@ -11407,10 +11427,10 @@ final class DashboardRuntimeStateTests: XCTestCase {
     try Self.writeProxyConfig(named: "Japan", to: configURL)
     let store = ProfileStore(paths: paths, keychain: InMemorySecretStore())
     _ = try await store.importLocalConfig(from: configURL)
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
-      defaults: try Self.makeIsolatedDefaults(),
+      defaults: Self.makeIsolatedDefaults(),
       bundledCoreURLProvider: { throw AppError.missingBundledCore }
     )
 
@@ -11443,10 +11463,10 @@ final class DashboardRuntimeStateTests: XCTestCase {
       session: URLSession(configuration: URLProtocolRecorder.configurationReturning(oldSource))
     )
     let preflightCore = try Self.makeRuleOverlayPreflightCore(in: paths.appSupport, rejectedToken: "never-matched")
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
-      defaults: try Self.makeIsolatedDefaults(),
+      defaults: Self.makeIsolatedDefaults(),
       bundledCoreURLProvider: { preflightCore }
     )
     await model.refreshEffectiveRuntimeConfigPreview()
@@ -11478,10 +11498,10 @@ final class DashboardRuntimeStateTests: XCTestCase {
     let store = ProfileStore(paths: paths, keychain: InMemorySecretStore())
     _ = try await store.importLocalConfig(from: configURL)
     let preflightCore = try Self.makeRuleOverlayPreflightCore(in: paths.appSupport, rejectedToken: "never-matched")
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
-      defaults: try Self.makeIsolatedDefaults(),
+      defaults: Self.makeIsolatedDefaults(),
       bundledCoreURLProvider: { preflightCore }
     )
     await model.refreshEffectiveRuntimeConfigPreview()
@@ -11495,7 +11515,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
         RuleOverlaySettings(
           enabled: true,
           appendRules: [
-            ManagedRuleOverlayRule(kind: .domainSuffix, value: "snippet.example", policy: "DIRECT")
+            ManagedRuleOverlayRule(kind: .domainSuffix, value: "snippet.example", policy: "DIRECT"),
           ]
         )
       )
@@ -11514,7 +11534,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
     """
     let store = ProfileStore(paths: paths, keychain: InMemorySecretStore())
     let profile = try await store.addSubscription(
-      url: try XCTUnwrap(URL(string: "https://example.com/sub")),
+      url: XCTUnwrap(URL(string: "https://example.com/sub")),
       session: URLSession(configuration: URLProtocolRecorder.configurationReturning(providerContent)),
       preflightValidator: NoopSubscriptionProfilePreflightValidator()
     )
@@ -11522,10 +11542,10 @@ final class DashboardRuntimeStateTests: XCTestCase {
       in: paths.appSupport,
       rejectedToken: "active-snippet.example"
     )
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
-      defaults: try Self.makeIsolatedDefaults(),
+      defaults: Self.makeIsolatedDefaults(),
       bundledCoreURLProvider: { rejectingCore }
     )
     await model.runtimeSnippetLibrary.waitForLoad()
@@ -11538,7 +11558,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
           RuleOverlaySettings(
             enabled: true,
             appendRules: [
-              ManagedRuleOverlayRule(kind: .domainSuffix, value: "active-snippet.example", policy: "DIRECT")
+              ManagedRuleOverlayRule(kind: .domainSuffix, value: "active-snippet.example", policy: "DIRECT"),
             ]
           )
         )
@@ -11564,7 +11584,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
     """
     let store = ProfileStore(paths: paths, keychain: InMemorySecretStore())
     let profile = try await store.addSubscription(
-      url: try XCTUnwrap(URL(string: "https://example.com/sub")),
+      url: XCTUnwrap(URL(string: "https://example.com/sub")),
       session: URLSession(configuration: URLProtocolRecorder.configurationReturning(providerContent)),
       preflightValidator: NoopSubscriptionProfilePreflightValidator()
     )
@@ -11573,11 +11593,11 @@ final class DashboardRuntimeStateTests: XCTestCase {
       .write(to: localProviderURL, atomically: true, encoding: .utf8)
     let validator = RecordingRuntimeConfigValidator(result: .success(()))
     let client = RecordingMihomoController(proxyGroupsResponse: [], testDelayResult: 0)
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
       apiClient: client,
-      defaults: try Self.makeIsolatedDefaults(),
+      defaults: Self.makeIsolatedDefaults(),
       bundledCoreURLProvider: { URL(fileURLWithPath: "/tmp/mihomo") },
       providerSideLoadPreflightRunner: MihomoProviderSideLoadPreflightRunner(runtimeConfigValidator: validator)
     )
@@ -11615,7 +11635,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
     """
     let profileStore = ProfileStore(paths: paths, keychain: secrets)
     let imported = try await profileStore.addSubscription(
-      url: try XCTUnwrap(URL(string: "https://example.com/sub")),
+      url: XCTUnwrap(URL(string: "https://example.com/sub")),
       session: URLSession(configuration: URLProtocolRecorder.configurationReturning(providerContent)),
       preflightValidator: NoopSubscriptionProfilePreflightValidator()
     )
@@ -11636,11 +11656,11 @@ final class DashboardRuntimeStateTests: XCTestCase {
     try "vless://00000000-0000-0000-0000-000000000000@local.example:443?security=tls#Local\n"
       .write(to: localProviderURL, atomically: true, encoding: .utf8)
     let validator = RecordingRuntimeConfigValidator(result: .success(()))
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: profileStore,
       outboundProxyEndpointStore: endpointStore,
-      defaults: try Self.makeIsolatedDefaults(),
+      defaults: Self.makeIsolatedDefaults(),
       bundledCoreURLProvider: { URL(fileURLWithPath: "/tmp/mihomo") },
       providerSideLoadPreflightRunner: MihomoProviderSideLoadPreflightRunner(runtimeConfigValidator: validator)
     )
@@ -11672,17 +11692,17 @@ final class DashboardRuntimeStateTests: XCTestCase {
     """
     let store = ProfileStore(paths: paths, keychain: InMemorySecretStore())
     let profile = try await store.addSubscription(
-      url: try XCTUnwrap(URL(string: "https://example.com/sub")),
+      url: XCTUnwrap(URL(string: "https://example.com/sub")),
       session: URLSession(configuration: URLProtocolRecorder.configurationReturning(configContent)),
       preflightValidator: NoopSubscriptionProfilePreflightValidator()
     )
     let localProviderURL = paths.appSupport.appendingPathComponent("local-provider.txt")
     try "trojan://password@local.example:443#Local\n".write(to: localProviderURL, atomically: true, encoding: .utf8)
     let validator = RecordingRuntimeConfigValidator(result: .success(()))
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
-      defaults: try Self.makeIsolatedDefaults(),
+      defaults: Self.makeIsolatedDefaults(),
       bundledCoreURLProvider: { URL(fileURLWithPath: "/tmp/mihomo") },
       providerSideLoadPreflightRunner: MihomoProviderSideLoadPreflightRunner(runtimeConfigValidator: validator)
     )
@@ -11708,17 +11728,17 @@ final class DashboardRuntimeStateTests: XCTestCase {
     """
     let store = ProfileStore(paths: paths, keychain: InMemorySecretStore())
     let profile = try await store.addSubscription(
-      url: try XCTUnwrap(URL(string: "https://example.com/sub")),
+      url: XCTUnwrap(URL(string: "https://example.com/sub")),
       session: URLSession(configuration: URLProtocolRecorder.configurationReturning(providerContent)),
       preflightValidator: NoopSubscriptionProfilePreflightValidator()
     )
     let localProviderURL = paths.appSupport.appendingPathComponent("bad-local-provider.txt")
     try "trojan://bad-password@local.example:443#Bad\n".write(to: localProviderURL, atomically: true, encoding: .utf8)
     let validator = RecordingRuntimeConfigValidator(result: .failure(AppError.configValidationFailed("bad local provider")))
-    let model = AppModel(
+    let model = try AppModel(
       paths: paths,
       profileStore: store,
-      defaults: try Self.makeIsolatedDefaults(),
+      defaults: Self.makeIsolatedDefaults(),
       bundledCoreURLProvider: { URL(fileURLWithPath: "/tmp/mihomo") },
       providerSideLoadPreflightRunner: MihomoProviderSideLoadPreflightRunner(runtimeConfigValidator: validator)
     )
@@ -11776,7 +11796,7 @@ final class DashboardRuntimeStateTests: XCTestCase {
       "/usr/sbin/networksetup -getsecurewebproxy Wi-Fi": "Enabled: No\nServer:\nPort: 0\n",
       "/usr/sbin/networksetup -getsocksfirewallproxy Wi-Fi": "Enabled: No\nServer:\nPort: 0\n",
       "/usr/sbin/networksetup -getproxybypassdomains Wi-Fi": "There aren't any bypass domains set.\n",
-      "/usr/sbin/networksetup -getdnsservers Wi-Fi": "There aren't any DNS Servers set on Wi-Fi.\n"
+      "/usr/sbin/networksetup -getdnsservers Wi-Fi": "There aren't any DNS Servers set on Wi-Fi.\n",
     ]
   }
 
@@ -12069,32 +12089,32 @@ final class DashboardRuntimeStateTests: XCTestCase {
         "Wi-Fi\n",
         "Wi-Fi\n",
         "Wi-Fi\n",
-        "Wi-Fi\n"
+        "Wi-Fi\n",
       ],
       "/usr/sbin/networksetup -getwebproxy Wi-Fi": [
         "Enabled: No\nServer:\nPort: 0\n",
         "Enabled: Yes\nServer: \(server)\nPort: 7890\n",
         "Enabled: Yes\nServer: \(server)\nPort: 7890\n",
-        "Enabled: No\nServer:\nPort: 0\n"
+        "Enabled: No\nServer:\nPort: 0\n",
       ],
       "/usr/sbin/networksetup -getsecurewebproxy Wi-Fi": [
         "Enabled: No\nServer:\nPort: 0\n",
         "Enabled: No\nServer:\nPort: 0\n",
         "Enabled: No\nServer:\nPort: 0\n",
-        "Enabled: No\nServer:\nPort: 0\n"
+        "Enabled: No\nServer:\nPort: 0\n",
       ],
       "/usr/sbin/networksetup -getsocksfirewallproxy Wi-Fi": [
         "Enabled: No\nServer:\nPort: 0\n",
         "Enabled: No\nServer:\nPort: 0\n",
         "Enabled: No\nServer:\nPort: 0\n",
-        "Enabled: No\nServer:\nPort: 0\n"
+        "Enabled: No\nServer:\nPort: 0\n",
       ],
       "/usr/sbin/networksetup -getproxybypassdomains Wi-Fi": [
         "There aren't any bypass domains set.\n",
         "There aren't any bypass domains set.\n",
         "There aren't any bypass domains set.\n",
-        "There aren't any bypass domains set.\n"
-      ]
+        "There aren't any bypass domains set.\n",
+      ],
     ]
   }
 
@@ -12132,7 +12152,8 @@ final class DashboardRuntimeStateTests: XCTestCase {
     for _ in 0..<120 {
       if let info = model.publicIPInfoState.info,
          !model.publicIPInfoState.isLoading,
-         expectedIP == nil || info.ipAddress == expectedIP {
+         expectedIP == nil || info.ipAddress == expectedIP
+      {
         return
       }
       await Task.yield()
@@ -13509,7 +13530,8 @@ private final class CountingProcessLauncher: CoreProcessLaunching {
   func launch(executable: URL, arguments: [String], environment: [String: String], workDirectory: URL) throws -> RunningCoreProcess {
     launchCount += 1
     if let configFlagIndex = arguments.firstIndex(of: "-f"),
-       arguments.indices.contains(configFlagIndex + 1) {
+       arguments.indices.contains(configFlagIndex + 1)
+    {
       launchedConfigPaths.append(arguments[configFlagIndex + 1])
     }
     return FakeRunningProcess(processIdentifier: Int32(1000 + launchCount))
@@ -13678,4 +13700,3 @@ private final class MutableCurrentNetworkProvider: CurrentNetworkProviding, @unc
     network
   }
 }
-

--- a/ClashMaxTests/ExternalControlHealthCheckerTests.swift
+++ b/ClashMaxTests/ExternalControlHealthCheckerTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import ClashMax
+import XCTest
 
 final class ExternalControlHealthCheckerTests: XCTestCase {
   func testControllerHealthCheckUsesVersionEndpointAndBearerSecret() async throws {
@@ -33,7 +33,7 @@ final class ExternalControlHealthCheckerTests: XCTestCase {
     XCTAssertEqual(request.httpMethod, "HEAD")
     XCTAssertEqual(request.url?.host, "dashboard.example")
     XCTAssertEqual(request.url?.path, "/app")
-    XCTAssertNil(URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)?.queryItems)
+    XCTAssertNil(try URLComponents(url: XCTUnwrap(request.url), resolvingAgainstBaseURL: false)?.queryItems)
     XCTAssertNil(request.value(forHTTPHeaderField: "Authorization"))
   }
 
@@ -44,7 +44,7 @@ final class ExternalControlHealthCheckerTests: XCTestCase {
       timeout: 0.5
     )
 
-    let result = await checker.checkDashboard(baseURL: try XCTUnwrap(URL(string: "https://dashboard.example")))
+    let result = try await checker.checkDashboard(baseURL: XCTUnwrap(URL(string: "https://dashboard.example")))
 
     XCTAssertEqual(result.status, .healthy)
     XCTAssertEqual(recorder.requests.map(\.httpMethod), ["HEAD", "GET"])
@@ -57,7 +57,7 @@ final class ExternalControlHealthCheckerTests: XCTestCase {
       timeout: 0.5
     )
 
-    let result = await checker.checkDashboard(baseURL: try XCTUnwrap(URL(string: "https://dashboard.example")))
+    let result = try await checker.checkDashboard(baseURL: XCTUnwrap(URL(string: "https://dashboard.example")))
 
     XCTAssertEqual(result.status, .failed)
     XCTAssertEqual(result.httpStatus, 503)

--- a/ClashMaxTests/GlobalShortcutSettingsTests.swift
+++ b/ClashMaxTests/GlobalShortcutSettingsTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import ClashMax
+import XCTest
 
 // Carbon key codes and modifier masks, spelled out so these expectations do not depend on
 // the machine's keyboard layout the way a rendered `displayName` does.
@@ -46,7 +46,7 @@ final class GlobalShortcutSettingsTests: XCTestCase {
     let settings = GlobalShortcutSettings(bindings: [
       GlobalShortcutBinding(action: .startStop, shortcut: arrow, enabled: true),
       GlobalShortcutBinding(action: .stop, shortcut: punctuation, enabled: true),
-      GlobalShortcutBinding(action: .restart, shortcut: functionKey, enabled: true)
+      GlobalShortcutBinding(action: .restart, shortcut: functionKey, enabled: true),
     ])
 
     XCTAssertNil(settings.validationError)
@@ -117,7 +117,7 @@ final class GlobalShortcutSettingsTests: XCTestCase {
   func testSettingsRejectCommandOnlyShortcuts() throws {
     let shortcut = try XCTUnwrap(KeyboardShortcutDescriptor(string: "cmd+p"))
     let settings = GlobalShortcutSettings(bindings: [
-      GlobalShortcutBinding(action: .startStop, shortcut: shortcut, enabled: true)
+      GlobalShortcutBinding(action: .startStop, shortcut: shortcut, enabled: true),
     ])
 
     XCTAssertEqual(shortcut.carbonModifiers, modifiersCommand)
@@ -132,7 +132,7 @@ final class GlobalShortcutSettingsTests: XCTestCase {
     let shortcut = try XCTUnwrap(KeyboardShortcutDescriptor(string: "cmd+shift+p"))
     let settings = GlobalShortcutSettings(bindings: [
       GlobalShortcutBinding(action: .startStop, shortcut: shortcut, enabled: true),
-      GlobalShortcutBinding(action: .toggleSystemProxy, shortcut: shortcut, enabled: true)
+      GlobalShortcutBinding(action: .toggleSystemProxy, shortcut: shortcut, enabled: true),
     ])
 
     XCTAssertNotNil(settings.validationError)
@@ -140,17 +140,17 @@ final class GlobalShortcutSettingsTests: XCTestCase {
   }
 
   func testAliasPairsConflictBeforeRegistration() throws {
-    let settings = GlobalShortcutSettings(bindings: [
+    let settings = try GlobalShortcutSettings(bindings: [
       GlobalShortcutBinding(
         action: .startStop,
-        shortcut: try XCTUnwrap(KeyboardShortcutDescriptor(string: "cmd+shift+enter")),
+        shortcut: XCTUnwrap(KeyboardShortcutDescriptor(string: "cmd+shift+enter")),
         enabled: true
       ),
       GlobalShortcutBinding(
         action: .toggleSystemProxy,
-        shortcut: try XCTUnwrap(KeyboardShortcutDescriptor(string: "cmd+shift+return")),
+        shortcut: XCTUnwrap(KeyboardShortcutDescriptor(string: "cmd+shift+return")),
         enabled: true
-      )
+      ),
     ])
 
     XCTAssertEqual(settings.conflictDescriptions.count, 1)
@@ -164,17 +164,17 @@ final class GlobalShortcutSettingsTests: XCTestCase {
   func testManagerRegistersOnlyEnabledValidBindings() throws {
     let registrar = RecordingGlobalShortcutRegistrar()
     let manager = GlobalShortcutManager(registrar: registrar)
-    let settings = GlobalShortcutSettings(bindings: [
+    let settings = try GlobalShortcutSettings(bindings: [
       GlobalShortcutBinding(
         action: .startStop,
-        shortcut: try XCTUnwrap(KeyboardShortcutDescriptor(string: "cmd+shift+p")),
+        shortcut: XCTUnwrap(KeyboardShortcutDescriptor(string: "cmd+shift+p")),
         enabled: true
       ),
       GlobalShortcutBinding(
         action: .stop,
-        shortcut: try XCTUnwrap(KeyboardShortcutDescriptor(string: "cmd+shift+s")),
+        shortcut: XCTUnwrap(KeyboardShortcutDescriptor(string: "cmd+shift+s")),
         enabled: false
-      )
+      ),
     ])
 
     let failures = manager.apply(settings) { _ in }
@@ -189,7 +189,7 @@ final class GlobalShortcutSettingsTests: XCTestCase {
     let registrar = RecordingGlobalShortcutRegistrar(failuresToReturn: [failure])
     let manager = GlobalShortcutManager(registrar: registrar)
     let settings = GlobalShortcutSettings(bindings: [
-      GlobalShortcutBinding(action: .startStop, shortcut: shortcut, enabled: true)
+      GlobalShortcutBinding(action: .startStop, shortcut: shortcut, enabled: true),
     ])
 
     let failures = manager.apply(settings) { _ in }

--- a/ClashMaxTests/HelperSetupGuidanceTests.swift
+++ b/ClashMaxTests/HelperSetupGuidanceTests.swift
@@ -1,7 +1,6 @@
+@testable import ClashMax
 import Foundation
 import XCTest
-
-@testable import ClashMax
 
 @MainActor
 final class HelperSetupGuidanceTests: XCTestCase {

--- a/ClashMaxTests/LocalizationTests.swift
+++ b/ClashMaxTests/LocalizationTests.swift
@@ -1,6 +1,6 @@
+@testable import ClashMax
 import Foundation
 import XCTest
-@testable import ClashMax
 
 final class LocalizationTests: XCTestCase {
   private let activeCatalogKeysThatMustRemainExtracted = [
@@ -34,7 +34,7 @@ final class LocalizationTests: XCTestCase {
     "Src Port",
     "Stop Core",
     "Trust this dashboard to receive the API secret automatically",
-    "Trusted for automatic secret autofill"
+    "Trusted for automatic secret autofill",
   ]
 
   func testStatusSectionAppearsAfterHome() {
@@ -449,7 +449,7 @@ final class LocalizationTests: XCTestCase {
         "所有网络代理节点和远程 Provider 均使用此上游。",
       "Not configured.": "未配置。",
       "Connection test failed. You can still save this endpoint for offline use.":
-        "连接测试失败。仍可保存此端点以供离线使用。"
+        "连接测试失败。仍可保存此端点以供离线使用。",
     ]
 
     for (key, expected) in expectedTranslations {
@@ -532,7 +532,7 @@ final class LocalizationTests: XCTestCase {
       "Sub-rule name": "子规则名称",
       "Sub-rule condition must be NETWORK,tcp or NETWORK,udp.": "子规则条件必须是 NETWORK,tcp 或 NETWORK,udp。",
       "Source IP CIDR must be a valid CIDR range.": "源 IP CIDR 必须是有效的 CIDR 网段。",
-      "Port rule value must be a port or range between 1 and 65535.": "端口规则值必须是 1 到 65535 之间的端口或范围。"
+      "Port rule value must be a port or range between 1 and 65535.": "端口规则值必须是 1 到 65535 之间的端口或范围。",
     ]
 
     for (key, expected) in expectedTranslations {

--- a/ClashMaxTests/MenuBarPanelLayoutTests.swift
+++ b/ClashMaxTests/MenuBarPanelLayoutTests.swift
@@ -1,8 +1,8 @@
 import AppKit
+@testable import ClashMax
 import ServiceManagement
 import SwiftUI
 import XCTest
-@testable import ClashMax
 
 @MainActor
 final class MenuBarPanelLayoutTests: XCTestCase {
@@ -44,7 +44,7 @@ final class MenuBarPanelLayoutTests: XCTestCase {
     XCTAssertEqual(size.width, MenuBarPanelLayout.width, accuracy: 1)
     // Content sits directly against the system panel's edge, inset only enough
     // to clear its rounded corners.
-    XCTAssertTrue((8 ... 16).contains(MenuBarPanelLayout.padding))
+    XCTAssertTrue((8...16).contains(MenuBarPanelLayout.padding))
   }
 
   func testFullPanelFitsPlannedWidthWithoutProfile() async throws {
@@ -296,7 +296,7 @@ final class MenuBarPanelLayoutTests: XCTestCase {
     // 312pt panel and on one compact line.
     let localizedTitles: [(locale: String, title: String)] = [
       ("en", "Proxy Mode"),
-      ("zh-Hans", "代理模式")
+      ("zh-Hans", "代理模式"),
     ]
 
     for testCase in localizedTitles {
@@ -399,7 +399,7 @@ final class MenuBarPanelLayoutTests: XCTestCase {
         "/Applications/One.app",
         "/Applications/Two.app",
         "/Applications/Three.app",
-        "/Applications/One.app"
+        "/Applications/One.app",
       ]
     )
   }
@@ -476,7 +476,7 @@ final class MenuBarPanelLayoutTests: XCTestCase {
       "/usr/sbin/networksetup -getsecurewebproxy Wi-Fi": "Enabled: No\nServer:\nPort: 0\n",
       "/usr/sbin/networksetup -getsocksfirewallproxy Wi-Fi": "Enabled: No\nServer:\nPort: 0\n",
       "/usr/sbin/networksetup -getproxybypassdomains Wi-Fi": "There aren't any bypass domains set.\n",
-      "/usr/sbin/networksetup -getdnsservers Wi-Fi": "There aren't any DNS Servers set on Wi-Fi.\n"
+      "/usr/sbin/networksetup -getdnsservers Wi-Fi": "There aren't any DNS Servers set on Wi-Fi.\n",
     ]
   }
 
@@ -486,7 +486,7 @@ final class MenuBarPanelLayoutTests: XCTestCase {
     TrafficSample(upload: 4096, download: 32768),
     TrafficSample(upload: 1024, download: 8192),
     TrafficSample(upload: 8192, download: 65536),
-    TrafficSample(upload: 4096, download: 32768)
+    TrafficSample(upload: 4096, download: 32768),
   ]
 }
 

--- a/ClashMaxTests/MenuBarRuntimePresentationTests.swift
+++ b/ClashMaxTests/MenuBarRuntimePresentationTests.swift
@@ -1,6 +1,6 @@
 import AppKit
-import XCTest
 @testable import ClashMax
+import XCTest
 
 final class MenuBarRuntimePresentationTests: XCTestCase {
   func testPresentationTitlesCoverMenuBarRuntimeStates() {
@@ -220,7 +220,7 @@ final class MenuBarStatusItemImageTests: XCTestCase {
     }
     let logoRegionMaxX = Int(MenuBarStatusItemImage.logoPointSize * 2)
     XCTAssertGreaterThan(
-      alphaPixels(in: rep, xRange: 0 ..< logoRegionMaxX),
+      alphaPixels(in: rep, xRange: 0..<logoRegionMaxX),
       0,
       "Logo must be drawn into the composite image"
     )
@@ -228,12 +228,12 @@ final class MenuBarStatusItemImageTests: XCTestCase {
     // carry real pixels — the empty-image / clipped-second-row regressions both
     // fail here.
     XCTAssertGreaterThan(
-      alphaPixels(in: rep, xRange: logoRegionMaxX ..< rep.pixelsWide, yRange: 0 ..< rep.pixelsHigh / 2),
+      alphaPixels(in: rep, xRange: logoRegionMaxX..<rep.pixelsWide, yRange: 0..<rep.pixelsHigh / 2),
       0,
       "Upload row must be drawn"
     )
     XCTAssertGreaterThan(
-      alphaPixels(in: rep, xRange: logoRegionMaxX ..< rep.pixelsWide, yRange: rep.pixelsHigh / 2 ..< rep.pixelsHigh),
+      alphaPixels(in: rep, xRange: logoRegionMaxX..<rep.pixelsWide, yRange: rep.pixelsHigh / 2..<rep.pixelsHigh),
       0,
       "Download row must be drawn"
     )
@@ -248,8 +248,8 @@ final class MenuBarStatusItemImageTests: XCTestCase {
     guard let rep = image.representations.first as? NSBitmapImageRep else {
       return XCTFail("Expected a pre-rasterized bitmap representation")
     }
-    XCTAssertGreaterThan(alphaPixels(in: rep, yRange: 0 ..< rep.pixelsHigh / 2), 0)
-    XCTAssertGreaterThan(alphaPixels(in: rep, yRange: rep.pixelsHigh / 2 ..< rep.pixelsHigh), 0)
+    XCTAssertGreaterThan(alphaPixels(in: rep, yRange: 0..<rep.pixelsHigh / 2), 0)
+    XCTAssertGreaterThan(alphaPixels(in: rep, yRange: rep.pixelsHigh / 2..<rep.pixelsHigh), 0)
   }
 
   private func solidLogo() -> NSImage {
@@ -266,8 +266,8 @@ final class MenuBarStatusItemImageTests: XCTestCase {
     yRange: Range<Int>? = nil
   ) -> Int {
     var count = 0
-    for x in xRange ?? 0 ..< rep.pixelsWide {
-      for y in yRange ?? 0 ..< rep.pixelsHigh {
+    for x in xRange ?? 0..<rep.pixelsWide {
+      for y in yRange ?? 0..<rep.pixelsHigh {
         if let color = rep.colorAt(x: x, y: y), color.alphaComponent > 0.1 {
           count += 1
         }
@@ -300,7 +300,7 @@ final class MenuBarNodeSelectionTests: XCTestCase {
       group(name: "Fallback", type: "Fallback"),
       group(name: "Auto", type: "URLTest"),
       group(name: "Elite", type: "Selector"),
-      group(name: "Region", type: "select")
+      group(name: "Region", type: "select"),
     ]
 
     let result = MenuBarNodeSelection.selectorGroups(from: groups, runMode: .rule)
@@ -311,7 +311,7 @@ final class MenuBarNodeSelectionTests: XCTestCase {
   func testGlobalGroupOnlyAppearsInGlobalMode() {
     let groups = [
       group(name: "Elite", type: "Selector"),
-      group(name: "GLOBAL", type: "Selector")
+      group(name: "GLOBAL", type: "Selector"),
     ]
 
     XCTAssertEqual(
@@ -336,7 +336,7 @@ final class MenuBarNodeSelectionTests: XCTestCase {
         type: "Selector",
         selected: nil,
         nodes: [node("Locked", selectable: false)]
-      )
+      ),
     ]
 
     XCTAssertEqual(
@@ -349,7 +349,7 @@ final class MenuBarNodeSelectionTests: XCTestCase {
     let groups = [
       group(name: "Elite", type: "Selector"),
       group(name: "Region", type: "select"),
-      group(name: "Backup", type: "Selector")
+      group(name: "Backup", type: "Selector"),
     ]
 
     // Pinned groups already render as their own flat rows, so the node-selection

--- a/ClashMaxTests/MihomoAPIClientTests.swift
+++ b/ClashMaxTests/MihomoAPIClientTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import ClashMax
+import XCTest
 
 final class MihomoAPIClientTests: XCTestCase {
   func testCoreAPIEndpointBuildsBracketedIPv6BaseURL() throws {
@@ -40,8 +40,7 @@ final class MihomoAPIClientTests: XCTestCase {
     do {
       _ = try await iterator.next()
       XCTFail("Expected invalid URL to throw")
-    } catch MihomoAPIClient.ClientError.invalidURL {
-    }
+    } catch MihomoAPIClient.ClientError.invalidURL {}
   }
 
   func testVersionRequestUsesConfiguredTimeout() async throws {
@@ -103,7 +102,8 @@ final class MihomoAPIClientTests: XCTestCase {
       XCTFail("Expected the delay probe to fail")
     } catch {
       guard let clientError = error as? MihomoAPIClient.ClientError,
-            case let .delayTestHTTPStatus(status) = clientError else {
+            case let .delayTestHTTPStatus(status) = clientError
+      else {
         return XCTFail("Expected delayTestHTTPStatus, got \(error)")
       }
       XCTAssertEqual(status, 503)
@@ -131,7 +131,8 @@ final class MihomoAPIClientTests: XCTestCase {
       XCTFail("Expected the delay probe to fail")
     } catch {
       guard let clientError = error as? MihomoAPIClient.ClientError,
-            case let .httpStatus(status) = clientError else {
+            case let .httpStatus(status) = clientError
+      else {
         return XCTFail("Expected httpStatus, got \(error)")
       }
       XCTAssertEqual(status, 401)
@@ -149,7 +150,7 @@ final class MihomoAPIClientTests: XCTestCase {
     try await client.selectProxy(group: "Auto/Asia", proxy: "HK 01")
 
     let request = try XCTUnwrap(recorder.lastRequest)
-    XCTAssertEqual(URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)?.percentEncodedPath, "/proxies/Auto%2FAsia")
+    XCTAssertEqual(try URLComponents(url: XCTUnwrap(request.url), resolvingAgainstBaseURL: false)?.percentEncodedPath, "/proxies/Auto%2FAsia")
   }
 
   func testProxyGroupsUseRuntimeProxyTypesForNodeRows() async throws {
@@ -231,7 +232,7 @@ final class MihomoAPIClientTests: XCTestCase {
 
     let request = try XCTUnwrap(recorder.lastRequest)
     XCTAssertEqual(request.httpMethod, "GET")
-    XCTAssertEqual(URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)?.percentEncodedPath, "/providers/proxies/remote%2Fsub/healthcheck")
+    XCTAssertEqual(try URLComponents(url: XCTUnwrap(request.url), resolvingAgainstBaseURL: false)?.percentEncodedPath, "/providers/proxies/remote%2Fsub/healthcheck")
   }
 
   func testProxyProvidersAreDecodedIntoStructuredRows() async throws {
@@ -276,9 +277,9 @@ final class MihomoAPIClientTests: XCTestCase {
         ),
         proxies: [
           ProxyNode(name: "Japan", type: "Vless", delay: nil, isSelectable: true, providerName: "remote"),
-          ProxyNode(name: "DIRECT", type: "Direct", delay: nil, isSelectable: true, providerName: "remote")
+          ProxyNode(name: "DIRECT", type: "Direct", delay: nil, isSelectable: true, providerName: "remote"),
         ]
-      )
+      ),
     ])
   }
 
@@ -312,7 +313,7 @@ final class MihomoAPIClientTests: XCTestCase {
         format: "yaml",
         updatedAt: ISO8601DateFormatter().date(from: "2026-05-05T09:30:00Z"),
         ruleCount: 42
-      )
+      ),
     ])
   }
 
@@ -339,7 +340,7 @@ final class MihomoAPIClientTests: XCTestCase {
         providerName: "local",
         raw: "DOMAIN-SUFFIX,example.com,DIRECT"
       ),
-      RuntimeRule(index: 2, type: "MATCH", payload: "", policy: "Proxy", raw: "MATCH,Proxy")
+      RuntimeRule(index: 2, type: "MATCH", payload: "", policy: "Proxy", raw: "MATCH,Proxy"),
     ])
   }
 
@@ -352,7 +353,7 @@ final class MihomoAPIClientTests: XCTestCase {
     var request = try XCTUnwrap(recorder.lastRequest)
     XCTAssertEqual(request.httpMethod, "PUT")
     XCTAssertEqual(
-      URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)?.percentEncodedPath,
+      try URLComponents(url: XCTUnwrap(request.url), resolvingAgainstBaseURL: false)?.percentEncodedPath,
       "/providers/proxies/remote%2Fsub"
     )
     XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer abc")
@@ -361,7 +362,7 @@ final class MihomoAPIClientTests: XCTestCase {
     request = try XCTUnwrap(recorder.lastRequest)
     XCTAssertEqual(request.httpMethod, "PUT")
     XCTAssertEqual(
-      URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)?.percentEncodedPath,
+      try URLComponents(url: XCTUnwrap(request.url), resolvingAgainstBaseURL: false)?.percentEncodedPath,
       "/providers/rules/rules%2Fsub"
     )
   }
@@ -415,7 +416,7 @@ final class MihomoAPIClientTests: XCTestCase {
     try await client.closeConnection(id: "abc/123")
     var request = try XCTUnwrap(recorder.lastRequest)
     XCTAssertEqual(request.httpMethod, "DELETE")
-    XCTAssertEqual(URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)?.percentEncodedPath, "/connections/abc%2F123")
+    XCTAssertEqual(try URLComponents(url: XCTUnwrap(request.url), resolvingAgainstBaseURL: false)?.percentEncodedPath, "/connections/abc%2F123")
     XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer abc")
 
     try await client.closeAllConnections()
@@ -428,18 +429,18 @@ final class MihomoAPIClientTests: XCTestCase {
     XCTAssertEqual(request.httpMethod, "PUT")
     XCTAssertEqual(request.url?.path, "/configs")
     XCTAssertEqual(request.url?.query, "force=true")
-    XCTAssertEqual(String(data: try XCTUnwrap(recorder.lastBody), encoding: .utf8), #"{"path":"/tmp/runtime.yaml"}"#)
+    XCTAssertEqual(try String(data: XCTUnwrap(recorder.lastBody), encoding: .utf8), #"{"path":"/tmp/runtime.yaml"}"#)
 
     try await client.updateIPv6(true)
     request = try XCTUnwrap(recorder.lastRequest)
     XCTAssertEqual(request.httpMethod, "PATCH")
     XCTAssertEqual(request.url?.path, "/configs")
-    XCTAssertEqual(String(data: try XCTUnwrap(recorder.lastBody), encoding: .utf8), #"{"ipv6":true}"#)
+    XCTAssertEqual(try String(data: XCTUnwrap(recorder.lastBody), encoding: .utf8), #"{"ipv6":true}"#)
 
     try await client.setTunEnabled(false)
     request = try XCTUnwrap(recorder.lastRequest)
     XCTAssertEqual(request.httpMethod, "PATCH")
     XCTAssertEqual(request.url?.path, "/configs")
-    XCTAssertEqual(String(data: try XCTUnwrap(recorder.lastBody), encoding: .utf8), #"{"tun":{"enable":false}}"#)
+    XCTAssertEqual(try String(data: XCTUnwrap(recorder.lastBody), encoding: .utf8), #"{"tun":{"enable":false}}"#)
   }
 }

--- a/ClashMaxTests/NetworkExtensionControllerTests.swift
+++ b/ClashMaxTests/NetworkExtensionControllerTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import ClashMax
+import XCTest
 
 @MainActor
 final class NetworkExtensionControllerTests: XCTestCase {
@@ -52,7 +52,7 @@ final class NetworkExtensionControllerTests: XCTestCase {
           isEnabled: false,
           isAwaitingUserApproval: true,
           isUninstalling: false
-        )
+        ),
       ]
     )
     let proxyManager = RecordingTransparentProxyManager(currentStatus: .connecting)
@@ -75,7 +75,7 @@ final class NetworkExtensionControllerTests: XCTestCase {
           isEnabled: true,
           isAwaitingUserApproval: false,
           isUninstalling: false
-        )
+        ),
       ]
     )
     let proxyManager = RecordingTransparentProxyManager(currentStatus: .notConfigured)
@@ -108,7 +108,7 @@ final class NetworkExtensionControllerTests: XCTestCase {
           isEnabled: true,
           isAwaitingUserApproval: false,
           isUninstalling: false
-        )
+        ),
       ]
     )
     let controller = NetworkExtensionController(
@@ -147,7 +147,7 @@ final class NetworkExtensionControllerTests: XCTestCase {
           isEnabled: true,
           isAwaitingUserApproval: false,
           isUninstalling: true
-        )
+        ),
       ]
     )
     let controller = NetworkExtensionController(
@@ -220,7 +220,7 @@ final class NetworkExtensionControllerTests: XCTestCase {
       "192.168.0.0/33",
       "fe80::/129",
       "example.com/24",
-      "192.168.0.0/not-a-prefix"
+      "192.168.0.0/not-a-prefix",
     ]
 
     for value in invalidValues {
@@ -260,7 +260,7 @@ final class NetworkExtensionControllerTests: XCTestCase {
           sourceAppSigningIdentifier: "io.github.clashmax.ClashMax",
           flowProtocol: .udp,
           remoteEndpoint: "127.0.0.1:53"
-        )
+        ),
       ],
       recentErrors: [
         NetworkExtensionDiagnosticEvent(
@@ -268,7 +268,7 @@ final class NetworkExtensionControllerTests: XCTestCase {
           message: "SOCKS5 failed.",
           flowProtocol: .tcp,
           remoteEndpoint: "example.com:443"
-        )
+        ),
       ],
       updatedAt: Date()
     )

--- a/ClashMaxTests/PageOverflowLayoutTests.swift
+++ b/ClashMaxTests/PageOverflowLayoutTests.swift
@@ -1,6 +1,6 @@
+@testable import ClashMax
 import SwiftUI
 import XCTest
-@testable import ClashMax
 
 /// Issue #27: sections whose height grew with their row count used to push a page past the window.
 /// SwiftUI grows a flexible frame to fit an oversized child instead of clipping it, so the overflow

--- a/ClashMaxTests/ProcessOutputCaptureTests.swift
+++ b/ClashMaxTests/ProcessOutputCaptureTests.swift
@@ -1,7 +1,7 @@
+@testable import ClashMax
 import Darwin
 import Foundation
 import Testing
-@testable import ClashMax
 
 struct ProcessOutputCaptureTests {
   @Test func capturesOutputLargerThanPipeBufferWithoutDeadlocking() async throws {
@@ -129,7 +129,8 @@ private func waitForRecordedPID(at url: URL, timeout: TimeInterval = 1) async th
     if let text = try? String(contentsOf: url, encoding: .utf8)
       .trimmingCharacters(in: .whitespacesAndNewlines),
       let pid = pid_t(text),
-      pid > 1 {
+      pid > 1
+    {
       return pid
     }
     try await Task.sleep(nanoseconds: 20_000_000)
@@ -156,7 +157,7 @@ private func terminateTestProcessIfNeeded(_ pid: pid_t) {
   guard pid > 1, isProcessAlive(pid) else { return }
   kill(pid, SIGTERM)
   let deadline = Date().addingTimeInterval(1)
-  while Date() < deadline && isProcessAlive(pid) {
+  while Date() < deadline, isProcessAlive(pid) {
     usleep(20_000)
   }
   if isProcessAlive(pid) {

--- a/ClashMaxTests/ProfileStoreTests.swift
+++ b/ClashMaxTests/ProfileStoreTests.swift
@@ -1,6 +1,6 @@
+@testable import ClashMax
 import Foundation
 import XCTest
-@testable import ClashMax
 
 @MainActor
 final class ProfileStoreTests: XCTestCase {
@@ -191,7 +191,7 @@ final class ProfileStoreTests: XCTestCase {
 
     XCTAssertEqual(object, [
       "kind": "manualProxy",
-      "endpointID": endpointID.uuidString
+      "endpointID": endpointID.uuidString,
     ])
     XCTAssertEqual(try JSONDecoder().decode(ProfileSource.self, from: data), source)
     XCTAssertEqual(source.displayName, String(localized: "Manual Proxy"))
@@ -304,7 +304,7 @@ final class ProfileStoreTests: XCTestCase {
           profileID: local.id,
           profileName: "Local via Office",
           kind: .upstream
-        )
+        ),
       ]
     )
   }
@@ -364,7 +364,7 @@ final class ProfileStoreTests: XCTestCase {
           profileID: upstream.id,
           profileName: upstream.name,
           kind: .upstream
-        )
+        ),
       ]
     )
   }
@@ -440,7 +440,7 @@ final class ProfileStoreTests: XCTestCase {
       responseHeaders: [
         "subscription-userinfo": "upload=1; download=2; total=3; expire=1893456000",
         "profile-update-interval": "6",
-        "profile-web-page-url": "https://example.com/dashboard"
+        "profile-web-page-url": "https://example.com/dashboard",
       ]
     )
     let session = URLSession(configuration: recorder.configuration)
@@ -502,7 +502,7 @@ final class ProfileStoreTests: XCTestCase {
         "clash-verge://install-config?url=https%3A%2F%2Fverge.example%2Fsub%3Ftoken%3Ddef&name=Verge%20Airport",
         "https://verge.example/sub?token=def",
         "Verge Airport"
-      )
+      ),
     ]
 
     for testCase in cases {
@@ -699,10 +699,10 @@ final class ProfileStoreTests: XCTestCase {
       ruleOverlay: RuleOverlaySettings(
         enabled: true,
         prependRules: [
-          ManagedRuleOverlayRule(kind: .domainSuffix, value: "corp.example", policy: "DIRECT")
+          ManagedRuleOverlayRule(kind: .domainSuffix, value: "corp.example", policy: "DIRECT"),
         ],
         disabledRuleMatchers: [
-          ManagedRuleDisableMatcher(mode: .contains, pattern: "ads.example")
+          ManagedRuleDisableMatcher(mode: .contains, pattern: "ads.example"),
         ]
       )
     )
@@ -743,10 +743,10 @@ final class ProfileStoreTests: XCTestCase {
       ruleOverlay: RuleOverlaySettings(
         enabled: true,
         prependRules: [
-          ManagedRuleOverlayRule(kind: .domainSuffix, value: "front.example", policy: "DIRECT")
+          ManagedRuleOverlayRule(kind: .domainSuffix, value: "front.example", policy: "DIRECT"),
         ],
         disabledRuleMatchers: [
-          ManagedRuleDisableMatcher(mode: .exact, pattern: "DOMAIN-SUFFIX,ads.example,REJECT")
+          ManagedRuleDisableMatcher(mode: .exact, pattern: "DOMAIN-SUFFIX,ads.example,REJECT"),
         ]
       )
     )
@@ -915,7 +915,7 @@ final class ProfileStoreTests: XCTestCase {
       ruleOverlay: RuleOverlaySettings(
         enabled: true,
         prependRules: [
-          ManagedRuleOverlayRule(kind: .ruleSet, value: "RemoteRules", policy: "Proxy")
+          ManagedRuleOverlayRule(kind: .ruleSet, value: "RemoteRules", policy: "Proxy"),
         ]
       )
     )
@@ -1012,7 +1012,7 @@ final class ProfileStoreTests: XCTestCase {
       responseBody: "proxies:\n  - name: DIRECT\n    type: direct\n",
       responseHeaders: [
         "Content-Type": "text/yaml; charset=UTF-8",
-        "subscription-userinfo": "upload=1; download=2; total=3"
+        "subscription-userinfo": "upload=1; download=2; total=3",
       ]
     )
 
@@ -1291,7 +1291,7 @@ final class ProfileStoreTests: XCTestCase {
       domain: "ClashMax.CoreValidation",
       code: Int(ETIMEDOUT),
       userInfo: [
-        NSLocalizedDescriptionKey: "Runtime config validation timed out after 30.0s.\n\(geodataStallOutput)"
+        NSLocalizedDescriptionKey: "Runtime config validation timed out after 30.0s.\n\(geodataStallOutput)",
       ]
     )
     let validator = RecordingSubscriptionPreflightValidator(result: .failure(timeoutError))
@@ -1453,7 +1453,7 @@ final class ProfileStoreTests: XCTestCase {
       responseBody: updatedSource,
       responseHeaders: [
         "Content-Type": "text/html; charset=UTF-8",
-        "subscription-userinfo": "upload=4; download=5; total=6"
+        "subscription-userinfo": "upload=4; download=5; total=6",
       ]
     )
 
@@ -2310,7 +2310,7 @@ final class OutboundProxyEndpointStoreTests: XCTestCase {
         BackupOutboundProxyEndpointPassword(
           endpointID: imported.id,
           password: "restored-secret"
-        )
+        ),
       ]
     )
 
@@ -2373,7 +2373,7 @@ final class OutboundProxyEndpointStoreTests: XCTestCase {
         kind: .socks5,
         host: "second.example",
         port: 1080
-      )
+      ),
     ]
     let duplicateNames = [
       OutboundProxyEndpoint(
@@ -2389,7 +2389,7 @@ final class OutboundProxyEndpointStoreTests: XCTestCase {
         kind: .socks5,
         host: "two.example",
         port: 1080
-      )
+      ),
     ]
     let store = OutboundProxyEndpointStore(
       manifestURL: URL(fileURLWithPath: "/unused/outbound-proxies.json"),
@@ -2443,7 +2443,7 @@ final class OutboundProxyEndpointStoreTests: XCTestCase {
         manifest: OutboundProxyEndpointManifest(endpoints: [endpoint]),
         passwords: [
           BackupOutboundProxyEndpointPassword(endpointID: endpoint.id, password: "first"),
-          BackupOutboundProxyEndpointPassword(endpointID: endpoint.id, password: "second")
+          BackupOutboundProxyEndpointPassword(endpointID: endpoint.id, password: "second"),
         ]
       )
       XCTFail("Expected duplicate endpoint password records to be rejected")
@@ -2477,7 +2477,7 @@ final class OutboundProxyEndpointStoreTests: XCTestCase {
       BackupOutboundProxyEndpointPassword(
         endpointID: missingID,
         password: "not-allowed"
-      )
+      ),
     ] {
       do {
         _ = try await store.mergeRestoreBackup(
@@ -2497,7 +2497,7 @@ final class OutboundProxyEndpointStoreTests: XCTestCase {
   func testManifestDecodingRejectsMissingRequiredFields() {
     for malformedJSON in [
       "{}",
-      #"{"schemaVersion":1}"#
+      #"{"schemaVersion":1}"#,
     ] {
       XCTAssertThrowsError(
         try JSONDecoder().decode(
@@ -2516,7 +2516,7 @@ final class OutboundProxyEndpointStoreTests: XCTestCase {
 
     for (index, malformedJSON) in [
       "{}",
-      #"{"schemaVersion":1}"#
+      #"{"schemaVersion":1}"#,
     ].enumerated() {
       let manifestURL = root.appendingPathComponent("malformed-\(index).json")
       try malformedJSON.write(to: manifestURL, atomically: true, encoding: .utf8)
@@ -2604,7 +2604,7 @@ final class OutboundProxyEndpointStoreTests: XCTestCase {
           BackupOutboundProxyEndpointPassword(
             endpointID: imported.id,
             password: "new-secret"
-          )
+          ),
         ]
       )
     }
@@ -2653,7 +2653,7 @@ final class OutboundProxyEndpointStoreTests: XCTestCase {
         BackupOutboundProxyEndpointPassword(
           endpointID: imported.id,
           password: "restored-secret"
-        )
+        ),
       ]
     )
 
@@ -2727,7 +2727,7 @@ final class OutboundProxyEndpointStoreTests: XCTestCase {
         manifest: OutboundProxyEndpointManifest(endpoints: [first, second]),
         passwords: [
           BackupOutboundProxyEndpointPassword(endpointID: first.id, password: "accepted-secret"),
-          BackupOutboundProxyEndpointPassword(endpointID: second.id, password: "rejected-secret")
+          BackupOutboundProxyEndpointPassword(endpointID: second.id, password: "rejected-secret"),
         ]
       )
     }
@@ -2966,7 +2966,7 @@ private actor ControllableProfileDiskIO: ProfileDiskStoring {
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
     encoder.dateEncodingStrategy = .iso8601
-    try SecureFileIO.writePrivateData(try encoder.encode(manifest), to: url, fileManager: fileManager)
+    try SecureFileIO.writePrivateData(encoder.encode(manifest), to: url, fileManager: fileManager)
   }
 
   func importLocalConfig(from sourceURL: URL, to destinationURL: URL) throws -> String {

--- a/ClashMaxTests/ProviderAnalyticsStoreTests.swift
+++ b/ClashMaxTests/ProviderAnalyticsStoreTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import ClashMax
+import XCTest
 
 @MainActor
 final class ProviderAnalyticsStoreTests: XCTestCase {
@@ -172,7 +172,7 @@ final class ProviderAnalyticsStoreTests: XCTestCase {
       updatedAt: nil,
       proxies: [
         Self.proxyNode(name: "Japan", type: "Vless"),
-        Self.proxyNode(name: "Singapore", type: "Vless")
+        Self.proxyNode(name: "Singapore", type: "Vless"),
       ]
     )
     let currentRuleProvider = RuleProvider(

--- a/ClashMaxTests/ProxyEffectDiagnosticsTests.swift
+++ b/ClashMaxTests/ProxyEffectDiagnosticsTests.swift
@@ -1,8 +1,7 @@
-import XCTest
 @testable import ClashMax
+import XCTest
 
 final class ProxyEffectDiagnosticsTests: XCTestCase {
-
   // MARK: Helpers
 
   private func makeInfo(
@@ -95,7 +94,7 @@ final class ProxyEffectDiagnosticsTests: XCTestCase {
           title: "Default route",
           status: .fail,
           message: "No utun default route present"
-        )
+        ),
       ],
       updatedAt: Date(timeIntervalSince1970: 1_700_000_000),
       externalProbeIncluded: true
@@ -243,7 +242,7 @@ final class ProxyEffectDiagnosticsTests: XCTestCase {
 
   func testProbeHostMatchingDirectRuleIsReportedWithRuleAndPolicy() {
     let rules = [
-      RuntimeRule(index: 1, type: "DOMAIN-SUFFIX", payload: "ip.sb", policy: "DIRECT")
+      RuntimeRule(index: 1, type: "DOMAIN-SUFFIX", payload: "ip.sb", policy: "DIRECT"),
     ]
 
     let snapshot = ProxyEffectDiagnosticsBuilder.build(

--- a/ClashMaxTests/ProxySearchPipelineTests.swift
+++ b/ClashMaxTests/ProxySearchPipelineTests.swift
@@ -1,6 +1,5 @@
-import XCTest
-
 @testable import ClashMax
+import XCTest
 
 /// Regression coverage for issue #10 (large proxy-list search performance).
 ///
@@ -10,7 +9,6 @@ import XCTest
 /// main thread only publishes finished snapshots.
 @MainActor
 final class ProxySearchPipelineTests: XCTestCase {
-
   // MARK: - Fixtures
 
   /// Builds a catalog with 1600+ resolvable nodes spread across regions, fronted by a provider
@@ -115,9 +113,9 @@ final class ProxySearchPipelineTests: XCTestCase {
         selected: nil,
         nodes: [
           ProxyNode(name: "JP Tokyo", type: "vless", delay: 83, isSelectable: true, providerName: "Remote"),
-          ProxyNode(name: "US Relay", type: "trojan", delay: 260, isSelectable: true, providerName: "Backup")
+          ProxyNode(name: "US Relay", type: "trojan", delay: 260, isSelectable: true, providerName: "Backup"),
         ]
-      )
+      ),
     ]
     func run(_ text: String) -> [String] {
       ProxySearchPipeline.run(
@@ -141,9 +139,9 @@ final class ProxySearchPipelineTests: XCTestCase {
         nodes: [
           ProxyNode(name: "z-node", type: "vless", delay: 200, isSelectable: true),
           ProxyNode(name: "a-node", type: "vless", delay: 50, isSelectable: true),
-          ProxyNode(name: "m-node", type: "vless", delay: 120, isSelectable: true)
+          ProxyNode(name: "m-node", type: "vless", delay: 120, isSelectable: true),
         ]
-      )
+      ),
     ]
     func order(_ sort: ProxyNodeSort) -> [String] {
       ProxySearchPipeline.run(
@@ -421,7 +419,7 @@ final class ProxySearchPipelineTests: XCTestCase {
       [
         ProxyNode(name: "z-node", type: "trojan", delay: delays[0], isSelectable: true),
         ProxyNode(name: "a-node", type: "vless", delay: delays[1], isSelectable: true),
-        ProxyNode(name: "m-node", type: "vmess", delay: delays[2], isSelectable: true)
+        ProxyNode(name: "m-node", type: "vmess", delay: delays[2], isSelectable: true),
       ]
     }
     func order(_ sort: ProxyNodeSort, _ delays: [Int]) -> [String] {
@@ -583,7 +581,7 @@ final class ProxySearchPipelineTests: XCTestCase {
       nodes: [
         ProxyNode(name: "韩国 001", type: "vless", delay: 80, isSelectable: true),
         ProxyNode(name: "美国 001", type: "vless", delay: 80, isSelectable: true),
-        ProxyNode(name: "日本 001", type: "vless", delay: 80, isSelectable: true)
+        ProxyNode(name: "日本 001", type: "vless", delay: 80, isSelectable: true),
       ]
     )
     func run(_ text: String) -> [String] {

--- a/ClashMaxTests/PublicIPInfoClientTests.swift
+++ b/ClashMaxTests/PublicIPInfoClientTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import ClashMax
+import XCTest
 
 final class PublicIPInfoClientTests: XCTestCase {
   func testMapsAllConfiguredGeoIPProviders() async throws {
@@ -21,7 +21,7 @@ final class PublicIPInfoClientTests: XCTestCase {
       """),
       ("geojs", """
       {"ip":"203.0.113.1","country_code":"NZ","country":"New Zealand","region":"Auckland","city":"Auckland","asn":"23655","organization":"Two Degrees Networks Limited","timezone":"Pacific/Auckland","latitude":"-36.85","longitude":"174.76"}
-      """)
+      """),
     ]
 
     for (providerName, body) in cases {
@@ -52,7 +52,7 @@ final class PublicIPInfoClientTests: XCTestCase {
 
   func testRecordsProviderHostAsSource() async throws {
     PublicIPInfoURLProtocol.configure([
-      .init(body: #"{"ip":"203.0.113.1","country_code":"NZ"}"#)
+      .init(body: #"{"ip":"203.0.113.1","country_code":"NZ"}"#),
     ])
     let provider = try XCTUnwrap(PublicIPInfoClient.Provider.defaultProviders.first { $0.name == "api.ip.sb" })
     let client = PublicIPInfoClient(
@@ -69,7 +69,7 @@ final class PublicIPInfoClientTests: XCTestCase {
 
   func testRequestUsesClashMaxUserAgentAndFiveSecondTimeout() async throws {
     PublicIPInfoURLProtocol.configure([
-      .init(body: #"{"ip":"203.0.113.1"}"#)
+      .init(body: #"{"ip":"203.0.113.1"}"#),
     ])
     let provider = PublicIPInfoClient.Provider.defaultProviders[0]
     let client = PublicIPInfoClient(
@@ -90,7 +90,7 @@ final class PublicIPInfoClientTests: XCTestCase {
   func testFallsBackToNextProviderAfterFailure() async throws {
     PublicIPInfoURLProtocol.configure([
       .init(statusCode: 503, body: #"{"error":"down"}"#),
-      .init(body: #"{"ip":"198.51.100.9","country_code":"US","country":"United States"}"#)
+      .init(body: #"{"ip":"198.51.100.9","country_code":"US","country":"United States"}"#),
     ])
     let providers = Array(PublicIPInfoClient.Provider.defaultProviders.prefix(2))
     let client = PublicIPInfoClient(
@@ -110,7 +110,7 @@ final class PublicIPInfoClientTests: XCTestCase {
   func testAllProvidersFailedReturnsUserReadableError() async throws {
     PublicIPInfoURLProtocol.configure([
       .init(statusCode: 500, body: #"{"error":"one"}"#),
-      .init(statusCode: 502, body: #"{"error":"two"}"#)
+      .init(statusCode: 502, body: #"{"error":"two"}"#),
     ])
     let client = PublicIPInfoClient(
       providers: Array(PublicIPInfoClient.Provider.defaultProviders.prefix(2)),
@@ -141,8 +141,8 @@ private struct PublicIPMockResponse {
 
 private final class PublicIPInfoURLProtocol: URLProtocol, @unchecked Sendable {
   private static let lock = NSLock()
-  nonisolated(unsafe) private static var responses: [PublicIPMockResponse] = []
-  nonisolated(unsafe) private static var requests: [URLRequest] = []
+  private nonisolated(unsafe) static var responses: [PublicIPMockResponse] = []
+  private nonisolated(unsafe) static var requests: [URLRequest] = []
 
   static func configure(_ newResponses: [PublicIPMockResponse]) {
     lock.lock()

--- a/ClashMaxTests/QuickRuleTests.swift
+++ b/ClashMaxTests/QuickRuleTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import ClashMax
+import XCTest
 
 /// Issue #15 phase B: adding a rule from the row that showed the problem, and then being told
 /// whether that rule is actually the one deciding the route.
@@ -196,7 +196,7 @@ final class QuickRuleTests: XCTestCase {
     let draft = QuickRuleDraft.targeting(host: "example.com", policy: "Proxy")
     let rules = [
       RuntimeRule(index: 1, type: "DomainKeyword", payload: "example", policy: "DIRECT", raw: "DOMAIN-KEYWORD,example,DIRECT"),
-      RuntimeRule(index: 2, type: "DomainSuffix", payload: "example.com", policy: "Proxy", raw: "DOMAIN-SUFFIX,example.com,Proxy")
+      RuntimeRule(index: 2, type: "DomainSuffix", payload: "example.com", policy: "Proxy", raw: "DOMAIN-SUFFIX,example.com,Proxy"),
     ]
 
     let input = try? XCTUnwrap(draft.verificationInput)
@@ -216,7 +216,7 @@ final class QuickRuleTests: XCTestCase {
     let draft = QuickRuleDraft.targeting(host: "example.com", policy: "Proxy")
     let rules = [
       RuntimeRule(index: 1, type: "DomainSuffix", payload: "example.com", policy: "Proxy", raw: "DOMAIN-SUFFIX,example.com,Proxy"),
-      RuntimeRule(index: 2, type: "DomainKeyword", payload: "example", policy: "DIRECT", raw: "DOMAIN-KEYWORD,example,DIRECT")
+      RuntimeRule(index: 2, type: "DomainKeyword", payload: "example", policy: "DIRECT", raw: "DOMAIN-KEYWORD,example,DIRECT"),
     ]
 
     let trace = RuleMatchSimulator().simulate(
@@ -433,7 +433,7 @@ final class QuickRuleTests: XCTestCase {
     let snippet = QuickRuleLibrary.disabling(raw, in: QuickRuleLibrary.targetSnippet(in: [], activeProfileID: nil))
     let runtimeRules = [
       RuntimeRule(index: 1, type: "DomainSuffix", payload: "ads.example.com", policy: "REJECT", raw: raw),
-      RuntimeRule(index: 2, type: "Match", payload: "", policy: "DIRECT", raw: "MATCH,DIRECT")
+      RuntimeRule(index: 2, type: "Match", payload: "", policy: "DIRECT", raw: "MATCH,DIRECT"),
     ]
 
     let candidates = RuntimeRuleCandidateBuilder.candidates(

--- a/ClashMaxTests/RuleMatchSimulatorRuleTypeTests.swift
+++ b/ClashMaxTests/RuleMatchSimulatorRuleTypeTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import ClashMax
+import XCTest
 
 /// The local rule simulator has to understand rule types in both spellings the app sees them in:
 /// `DOMAIN-SUFFIX` as written in a config, and `DomainSuffix` as a running Mihomo core reports it
@@ -147,7 +147,7 @@ final class RuleMatchSimulatorRuleTypeTests: XCTestCase {
     for type in [
       "GEOIP", "GeoIP", "GEOSITE", "GeoSite", "RULE-SET", "RuleSet", "SUB-RULE",
       "SRC-GEOIP", "SrcGeoIP", "SRC-IP-ASN", "SRC-IP-SUFFIX", "SrcIPSuffix",
-      "IP-SUFFIX", "IPSuffix", "NETWORK", "Network"
+      "IP-SUFFIX", "IPSuffix", "NETWORK", "Network",
     ] {
       let trace = simulator.simulate(
         input: RuleMatchSimulationInput(destination: "example.com"),
@@ -164,7 +164,7 @@ final class RuleMatchSimulatorRuleTypeTests: XCTestCase {
     // substring fallback and swallow domain traffic that a later rule should have taken.
     let rules = [
       rule("IPCIDR", "10.0.0.0/8", "Wrong", index: 1),
-      rule("DomainSuffix", "example.com", "Right", index: 2)
+      rule("DomainSuffix", "example.com", "Right", index: 2),
     ]
 
     XCTAssertEqual(

--- a/ClashMaxTests/RuntimeChangeApplyModeTests.swift
+++ b/ClashMaxTests/RuntimeChangeApplyModeTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import ClashMax
+import XCTest
 
 final class RuntimeChangeApplyModeTests: XCTestCase {
   func testRuleAndDNSEditsHotReloadForEveryRunningOwner() {
@@ -23,7 +23,7 @@ final class RuntimeChangeApplyModeTests: XCTestCase {
       .profileOptions,
       .inboundPort,
       .controllerEndpoint,
-      .networkExtensionRouting
+      .networkExtensionRouting,
     ] {
       XCTAssertEqual(RuntimeChangeApplyMode.resolve(change, in: .stopped), .appliesOnNextStart)
     }
@@ -82,7 +82,7 @@ final class RuntimeChangeApplyModeTests: XCTestCase {
     for outcome: RuntimeApplyOutcome in [
       .applied(.rules),
       .restartNeeded(.inboundPort, .networkExtensionEndpointPinned),
-      .savedForNextStart(.dns)
+      .savedForNextStart(.dns),
     ] {
       XCTAssertFalse(outcome.isFailure)
       XCTAssertFalse(outcome.title.isEmpty)

--- a/ClashMaxTests/RuntimeDataStoreTests.swift
+++ b/ClashMaxTests/RuntimeDataStoreTests.swift
@@ -1,6 +1,6 @@
+@testable import ClashMax
 import Observation
 import XCTest
-@testable import ClashMax
 
 @MainActor
 final class RuntimeDataStoreTests: XCTestCase {

--- a/ClashMaxTests/RuntimeSnippetLibraryStoreTests.swift
+++ b/ClashMaxTests/RuntimeSnippetLibraryStoreTests.swift
@@ -1,6 +1,6 @@
+@testable import ClashMax
 import Foundation
 import XCTest
-@testable import ClashMax
 
 @MainActor
 final class RuntimeSnippetLibraryStoreTests: XCTestCase {
@@ -109,7 +109,7 @@ final class RuntimeSnippetLibraryStoreTests: XCTestCase {
         RuleOverlaySettings(
           enabled: true,
           prependRules: [
-            ManagedRuleOverlayRule(kind: .domainSuffix, value: "invalid.example", policy: "DIRECT")
+            ManagedRuleOverlayRule(kind: .domainSuffix, value: "invalid.example", policy: "DIRECT"),
           ]
         )
       )
@@ -206,7 +206,7 @@ final class RuntimeSnippetLibraryStoreTests: XCTestCase {
         RuleOverlaySettings(
           enabled: true,
           prependRules: [
-            ManagedRuleOverlayRule(kind: .domainSuffix, value: domain, policy: "DIRECT")
+            ManagedRuleOverlayRule(kind: .domainSuffix, value: domain, policy: "DIRECT"),
           ]
         )
       )

--- a/ClashMaxTests/Socks5ConnectRequestTests.swift
+++ b/ClashMaxTests/Socks5ConnectRequestTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import ClashMax
+import XCTest
 
 final class Socks5ConnectRequestTests: XCTestCase {
   func testIPv4ConnectRequestEncoding() throws {
@@ -72,7 +72,7 @@ final class Socks5ConnectRequestTests: XCTestCase {
 
   func testReplyParserDecodesIPv6BindEndpoint() throws {
     var data = Data([0x05, 0x00, 0x00, 0x04])
-    data.append(try Socks5ConnectRequest.bytes(forIPv6Address: "2001:db8::1"))
+    try data.append(Socks5ConnectRequest.bytes(forIPv6Address: "2001:db8::1"))
     data.append(contentsOf: [0x00, 0x35])
 
     let reply = try Socks5ReplyParser.parse(data)
@@ -147,7 +147,7 @@ final class Socks5ConnectRequestTests: XCTestCase {
       Data([0x00, 0x00, 0x00]),
       Data([0x00, 0x00, 0x00, 0x01, 8, 8, 8, 8, 0x00]),
       Data([0x00, 0x00, 0x00, 0x03, 0x03, 0x64, 0x6e, 0x73, 0x00]),
-      Data([0x00, 0x00, 0x00, 0x04] + Array(repeating: 0x00, count: 15))
+      Data([0x00, 0x00, 0x00, 0x04] + Array(repeating: 0x00, count: 15)),
     ]
 
     for sample in truncatedSamples {

--- a/ClashMaxTests/StructuredLogProducerTests.swift
+++ b/ClashMaxTests/StructuredLogProducerTests.swift
@@ -1,11 +1,10 @@
-import XCTest
 @testable import ClashMax
+import XCTest
 
 /// Covers the process-boundary layer of structured logging: level normalization,
 /// source-side credential redaction, and the byte-stream accumulator every producer
 /// (Mihomo stdout, helper, network extension) feeds its output through.
 final class StructuredLogProducerTests: XCTestCase {
-
   // MARK: - Level normalization
 
   func testProducerLevelNormalizesAliasesAndPreservesUnknownRawValue() {
@@ -139,7 +138,7 @@ final class StructuredLogProducerTests: XCTestCase {
     decoder.dateDecodingStrategy = .iso8601
     let decoded = try decoder.decode(
       ProducerLogEvent.self,
-      from: try encoder.encode(event)
+      from: encoder.encode(event)
     )
     XCTAssertEqual(decoded, event)
   }
@@ -173,7 +172,7 @@ final class StructuredLogProducerTests: XCTestCase {
   func testAccumulatorSurvivesInvalidUTF8() {
     var accumulator = SanitizedLineAccumulator()
     var data = Data("ok ".utf8)
-    data.append(contentsOf: [0xFF, 0xFE, 0xC3])
+    data.append(contentsOf: [0xff, 0xfe, 0xc3])
     data.append(contentsOf: Array("\n".utf8))
     let lines = accumulator.append(data)
     XCTAssertEqual(lines.count, 1)

--- a/ClashMaxTests/SubscriptionFetcherTests.swift
+++ b/ClashMaxTests/SubscriptionFetcherTests.swift
@@ -1,7 +1,7 @@
+@testable import ClashMax
 import Foundation
 import Network
 import XCTest
-@testable import ClashMax
 
 final class SubscriptionFetcherTests: XCTestCase {
   func testProfileUpstreamBindingForcesStrictRetryAndProviderCannotOverrideIt() async throws {
@@ -51,7 +51,7 @@ final class SubscriptionFetcherTests: XCTestCase {
     for fetchProxy in [
       SubscriptionProviderFetchProxy.direct,
       .localClashProxy,
-      .systemProxy
+      .systemProxy,
     ] {
       let options = SubscriptionProviderOptions(fetchProxy: fetchProxy)
         .fetchOptions(from: base)
@@ -213,7 +213,7 @@ final class SubscriptionFetcherTests: XCTestCase {
   func testProfileUpstreamWrongPasswordFailsClosedForLocalSOCKS5AndHTTPConnect() async throws {
     for kind in [
       LocalSubscriptionProxyServer.Kind.socks5,
-      .httpConnect
+      .httpConnect,
     ] {
       let proxy = try LocalSubscriptionProxyServer(
         kind: kind,
@@ -234,7 +234,7 @@ final class SubscriptionFetcherTests: XCTestCase {
 
       do {
         _ = try await SubscriptionFetcher().fetch(
-          url: try XCTUnwrap(URL(string: "https://subscription.invalid/profile")),
+          url: XCTUnwrap(URL(string: "https://subscription.invalid/profile")),
           options: SubscriptionFetchOptions(
             timeout: 2,
             retryOrder: [.direct, .systemProxy],
@@ -379,7 +379,7 @@ final class SubscriptionFetcherTests: XCTestCase {
       ("bad host", 1080),
       ("https://proxy.example.com", 1080),
       ("proxy.example.com", 0),
-      ("proxy.example.com", 65_536)
+      ("proxy.example.com", 65_536),
     ]
     for (host, port) in invalidEndpoints {
       let endpoint = ResolvedOutboundProxyEndpoint(
@@ -412,7 +412,7 @@ final class SubscriptionFetcherTests: XCTestCase {
     let options = SubscriptionFetchOptions(
       customHeaders: [
         "Proxy-Authorization": "Basic sensitive-auth-header",
-        "X-Safe": "present"
+        "X-Safe": "present",
       ],
       profileUpstreamEndpoint: endpoint
     )
@@ -427,27 +427,27 @@ final class SubscriptionFetcherTests: XCTestCase {
           code: 1,
           userInfo: [
             NSLocalizedDescriptionKey:
-              "sensitive-password Proxy-Authorization Basic sensitive-auth-header"
+              "sensitive-password Proxy-Authorization Basic sensitive-auth-header",
           ]
         )
       }
       XCTFail("Expected transport failure")
     } catch let error as SubscriptionFetchError {
-      let diagnosticsJSON = String(
-        decoding: try JSONEncoder().encode(error.diagnostics),
+      let diagnosticsJSON = try String(
+        decoding: JSONEncoder().encode(error.diagnostics),
         as: UTF8.self
       )
       let combined = [
         error.message,
         error.description,
         error.localizedDescription,
-        diagnosticsJSON
+        diagnosticsJSON,
       ].joined(separator: "\n")
       for sensitiveValue in [
         "sensitive-user",
         "sensitive-password",
         "sensitive-auth-header",
-        "Proxy-Authorization"
+        "Proxy-Authorization",
       ] {
         XCTAssertFalse(combined.contains(sensitiveValue), "Leaked \(sensitiveValue)")
       }
@@ -483,8 +483,8 @@ final class SubscriptionFetcherTests: XCTestCase {
         }
         XCTFail("Expected transport failure")
       } catch let error as SubscriptionFetchError {
-        let diagnosticsJSON = String(
-          decoding: try JSONEncoder().encode(error.diagnostics),
+        let diagnosticsJSON = try String(
+          decoding: JSONEncoder().encode(error.diagnostics),
           as: UTF8.self
         )
         let combined = "\(error.message)\n\(error.localizedDescription)\n\(diagnosticsJSON)"
@@ -511,7 +511,7 @@ final class SubscriptionFetcherTests: XCTestCase {
         "response"
       ),
       (
-        Data([0xFF, 0xFE, 0xFF]),
+        Data([0xff, 0xfe, 0xff]),
         HTTPURLResponse(
           url: url,
           statusCode: 200,
@@ -531,7 +531,7 @@ final class SubscriptionFetcherTests: XCTestCase {
         )!,
         .invalidProfile,
         "validation"
-      )
+      ),
     ]
 
     for (data, response, expectedKind, expectedStage) in cases {
@@ -584,8 +584,8 @@ final class SubscriptionFetcherTests: XCTestCase {
       )
     }
 
-    let diagnosticsJSON = String(
-      decoding: try JSONEncoder().encode(result.diagnostics),
+    let diagnosticsJSON = try String(
+      decoding: JSONEncoder().encode(result.diagnostics),
       as: UTF8.self
     )
     XCTAssertEqual(result.diagnostics.endpointName, "Safe endpoint name")
@@ -594,7 +594,7 @@ final class SubscriptionFetcherTests: XCTestCase {
       "sensitive-user",
       "sensitive-password",
       "sensitive-auth-header",
-      "Proxy-Authorization"
+      "Proxy-Authorization",
     ] {
       XCTAssertFalse(diagnosticsJSON.contains(sensitiveValue), "Leaked \(sensitiveValue)")
     }
@@ -655,7 +655,7 @@ final class SubscriptionFetcherTests: XCTestCase {
     let url = URL(string: "https://example.com/sub")!
     let customHeaders = [
       "pRoXy-AuThOrIzAtIoN": "Basic sensitive-proxy-credential",
-      "X-Panel-Token": "safe-custom-header"
+      "X-Panel-Token": "safe-custom-header",
     ]
 
     var endpointBoundOptions = SubscriptionFetchOptions(
@@ -734,7 +734,7 @@ final class SubscriptionFetcherTests: XCTestCase {
     let providerOptions = SubscriptionProviderOptions(
       requestHeaders: [
         SubscriptionRequestHeader(name: " X-Token ", value: " secret "),
-        SubscriptionRequestHeader(name: " ", value: "ignored")
+        SubscriptionRequestHeader(name: " ", value: "ignored"),
       ],
       fetchProxy: .localClashProxy
     )
@@ -748,14 +748,14 @@ final class SubscriptionFetcherTests: XCTestCase {
   func testResolverAcceptsAdditionalClashDeepLinkSchemes() throws {
     let cases = [
       "clashmeta://install-config?url=https%3A%2F%2Fexample.com%2Fsub%3Ftoken%3Dabc&name=Meta",
-      "flclash://install-config?url=https%3A%2F%2Fexample.com%2Fsub%3Ftoken%3Ddef&name=FlClash"
+      "flclash://install-config?url=https%3A%2F%2Fexample.com%2Fsub%3Ftoken%3Ddef&name=FlClash",
     ]
 
     let resolved = cases.compactMap { SubscriptionURLResolver.resolve(rawInput: $0) }
 
     XCTAssertEqual(resolved.map(\.url.absoluteString), [
       "https://example.com/sub?token=abc",
-      "https://example.com/sub?token=def"
+      "https://example.com/sub?token=def",
     ])
     XCTAssertEqual(resolved.map(\.displayNameHint), ["Meta", "FlClash"])
   }
@@ -772,7 +772,7 @@ final class SubscriptionFetcherTests: XCTestCase {
         "subscription-userinfo": "upload=1024; download=2048; total=4096; expire=1893456000",
         "content-disposition": "attachment; filename*=UTF-8''Remote%20Profile.yaml",
         "profile-update-interval": "12",
-        "profile-web-page-url": "https://example.com/dashboard"
+        "profile-web-page-url": "https://example.com/dashboard",
       ]
     )!
 
@@ -840,7 +840,7 @@ final class SubscriptionFetcherTests: XCTestCase {
       statusCode: 200,
       httpVersion: nil,
       headerFields: [
-        "x-amz-meta-subscription-userinfo": "upload=512; download=1024; total=2048"
+        "x-amz-meta-subscription-userinfo": "upload=512; download=1024; total=2048",
       ]
     )!
 
@@ -892,7 +892,7 @@ final class SubscriptionFetcherTests: XCTestCase {
       headerFields: [
         "Content-Type": "text/html; charset=UTF-8",
         "subscription-userinfo": "upload=1; download=2; total=3",
-        "content-disposition": "attachment; filename*=UTF-8''Remote%20Profile.yaml"
+        "content-disposition": "attachment; filename*=UTF-8''Remote%20Profile.yaml",
       ]
     )!
 
@@ -1210,7 +1210,6 @@ private actor StrategyAttemptRecorder {
   func strategies() -> [SubscriptionFetchStrategy] {
     attemptedStrategies
   }
-
 }
 
 private actor UserAgentAttemptRecorder {
@@ -1223,7 +1222,6 @@ private actor UserAgentAttemptRecorder {
   func userAgents() -> [String] {
     recordedUserAgents
   }
-
 }
 
 private func profileUpstreamEndpoint() -> ResolvedOutboundProxyEndpoint {
@@ -1292,7 +1290,7 @@ private final class LocalOpenSSLSubscriptionOrigin: @unchecked Sendable {
         "-cert", "cert.pem",
         "-key", "key.pem",
         "-WWW",
-        "-quiet"
+        "-quiet",
       ]
       process.currentDirectoryURL = directoryURL
       process.standardOutput = FileHandle.nullDevice
@@ -1340,7 +1338,7 @@ private final class LocalOpenSSLSubscriptionOrigin: @unchecked Sendable {
       "-keyout", "key.pem",
       "-out", "cert.pem",
       "-subj", "/CN=subscription.local",
-      "-days", "1"
+      "-days", "1",
     ]
     generator.currentDirectoryURL = directoryURL
     generator.standardOutput = FileHandle.nullDevice
@@ -1703,15 +1701,15 @@ private final class LocalSubscriptionProxyConnectionHandler: @unchecked Sendable
         return
       }
       let methodCount = Int(header[header.index(after: header.startIndex)])
-      self.readExactly(methodCount) { [weak self] methods in
+      readExactly(methodCount) { [weak self] methods in
         guard let self else { return }
-        let requiresAuthentication = self.username != nil || self.password != nil
+        let requiresAuthentication = username != nil || password != nil
         let method: UInt8 = requiresAuthentication ? 0x02 : 0x00
         guard methods.contains(method) else {
-          self.send(Data([0x05, 0xFF]), closeAfterSending: true)
+          send(Data([0x05, 0xff]), closeAfterSending: true)
           return
         }
-        self.send(Data([0x05, method])) { [weak self] in
+        send(Data([0x05, method])) { [weak self] in
           if requiresAuthentication {
             self?.readSOCKS5Authentication()
           } else {
@@ -1730,7 +1728,7 @@ private final class LocalSubscriptionProxyConnectionHandler: @unchecked Sendable
         return
       }
       let usernameLength = Int(header[header.index(after: header.startIndex)])
-      self.readExactly(usernameLength + 1) { [weak self] usernameAndPasswordLength in
+      readExactly(usernameLength + 1) { [weak self] usernameAndPasswordLength in
         guard let self,
               let passwordLengthByte = usernameAndPasswordLength.last
         else {
@@ -1741,13 +1739,13 @@ private final class LocalSubscriptionProxyConnectionHandler: @unchecked Sendable
           decoding: usernameAndPasswordLength.dropLast(),
           as: UTF8.self
         )
-        self.readExactly(Int(passwordLengthByte)) { [weak self] passwordData in
+        readExactly(Int(passwordLengthByte)) { [weak self] passwordData in
           guard let self else { return }
           let receivedPassword = String(decoding: passwordData, as: UTF8.self)
-          let accepted = receivedUsername == self.username
-            && receivedPassword == self.password
-          self.recordAuthentication(accepted)
-          self.send(Data([0x01, accepted ? 0x00 : 0x01]), closeAfterSending: !accepted) { [weak self] in
+          let accepted = receivedUsername == username
+            && receivedPassword == password
+          recordAuthentication(accepted)
+          send(Data([0x01, accepted ? 0x00 : 0x01]), closeAfterSending: !accepted) { [weak self] in
             self?.readSOCKS5ConnectRequest()
           }
         }
@@ -1767,15 +1765,15 @@ private final class LocalSubscriptionProxyConnectionHandler: @unchecked Sendable
       let addressType = header[header.index(header.startIndex, offsetBy: 3)]
       switch addressType {
       case 0x01:
-        self.readExactly(6) { [weak self] addressAndPort in
+        readExactly(6) { [weak self] addressAndPort in
           let bytes = Array(addressAndPort)
           let target = "\(bytes[0]).\(bytes[1]).\(bytes[2]).\(bytes[3]):\(Int(bytes[4]) << 8 | Int(bytes[5]))"
           self?.completeSOCKS5Connect(target: target)
         }
       case 0x03:
-        self.readExactly(1) { [weak self] lengthData in
+        readExactly(1) { [weak self] lengthData in
           guard let self, let length = lengthData.first else { return }
-          self.readExactly(Int(length) + 2) { [weak self] hostAndPort in
+          readExactly(Int(length) + 2) { [weak self] hostAndPort in
             let hostBytes = hostAndPort.dropLast(2)
             let portBytes = hostAndPort.suffix(2)
             let port = Int(portBytes[portBytes.startIndex]) << 8
@@ -1786,7 +1784,7 @@ private final class LocalSubscriptionProxyConnectionHandler: @unchecked Sendable
           }
         }
       case 0x04:
-        self.readExactly(18) { [weak self] addressAndPort in
+        readExactly(18) { [weak self] addressAndPort in
           let bytes = Array(addressAndPort)
           let groups = stride(from: 0, to: 16, by: 2).map {
             String(format: "%02x%02x", bytes[$0], bytes[$0 + 1])
@@ -1822,13 +1820,13 @@ private final class LocalSubscriptionProxyConnectionHandler: @unchecked Sendable
         guard let separator = line.firstIndex(of: ":") else { return nil }
         return String(line[..<separator]).lowercased()
       }
-      self.recordTarget(
+      recordTarget(
         "\(requestLine) headers=\(headerNames.sorted().joined(separator: ","))"
       )
-      let accepted = self.httpProxyAuthorizationIsValid(header)
-      self.recordAuthentication(accepted)
+      let accepted = httpProxyAuthorizationIsValid(header)
+      recordAuthentication(accepted)
       guard accepted else {
-        self.sendFinal(
+        sendFinal(
           Data((
             "HTTP/1.1 407 Proxy Authentication Required\r\n"
               + "Proxy-Authenticate: Basic realm=\"ClashMax Tests\"\r\n"
@@ -1843,15 +1841,15 @@ private final class LocalSubscriptionProxyConnectionHandler: @unchecked Sendable
 
       if requestLine.uppercased().hasPrefix("CONNECT ") {
         let successResponse = Data("HTTP/1.1 200 Connection Established\r\n\r\n".utf8)
-        if self.relayPort != nil {
-          self.connectToRelay(proxySuccessResponse: successResponse)
+        if relayPort != nil {
+          connectToRelay(proxySuccessResponse: successResponse)
         } else {
-          self.send(successResponse) { [weak self] in
+          send(successResponse) { [weak self] in
             self?.readTunneledHTTPRequest()
           }
         }
       } else {
-        self.sendSubscriptionResponse()
+        sendSubscriptionResponse()
       }
     }
   }
@@ -1919,13 +1917,13 @@ private final class LocalSubscriptionProxyConnectionHandler: @unchecked Sendable
       switch state {
       case .ready:
         upstream.stateUpdateHandler = nil
-        self.send(proxySuccessResponse) { [weak self, weak upstream] in
+        send(proxySuccessResponse) { [weak self, weak upstream] in
           guard let self, let upstream else { return }
-          self.relay(from: self.connection, to: upstream, recordsResponse: false)
-          self.relay(from: upstream, to: self.connection, recordsResponse: true)
+          relay(from: connection, to: upstream, recordsResponse: false)
+          relay(from: upstream, to: connection, recordsResponse: true)
         }
       case .failed, .cancelled:
-        self.finish()
+        finish()
       default:
         break
       }
@@ -1944,16 +1942,16 @@ private final class LocalSubscriptionProxyConnectionHandler: @unchecked Sendable
     ) { [weak self, weak source, weak destination] data, _, isComplete, error in
       guard let self, let source, let destination else { return }
       if let data, !data.isEmpty {
-        if recordsResponse, !self.recordedRelayResponse {
-          self.recordedRelayResponse = true
-          self.recordResponse()
+        if recordsResponse, !recordedRelayResponse {
+          recordedRelayResponse = true
+          recordResponse()
         }
         destination.send(content: data, completion: .contentProcessed { [weak self] sendError in
           guard let self else { return }
           if sendError != nil || isComplete {
-            self.finish()
+            finish()
           } else {
-            self.relay(
+            relay(
               from: source,
               to: destination,
               recordsResponse: recordsResponse
@@ -1961,9 +1959,9 @@ private final class LocalSubscriptionProxyConnectionHandler: @unchecked Sendable
           }
         })
       } else if error != nil || isComplete {
-        self.finish()
+        finish()
       } else {
-        self.relay(
+        relay(
           from: source,
           to: destination,
           recordsResponse: recordsResponse
@@ -2015,10 +2013,10 @@ private final class LocalSubscriptionProxyConnectionHandler: @unchecked Sendable
     ) { [weak self] data, _, isComplete, error in
       guard let self else { return }
       if let data, !data.isEmpty {
-        self.buffer.append(data)
+        buffer.append(data)
       }
-      if error != nil || (isComplete && self.buffer.isEmpty) {
-        self.finish()
+      if error != nil || (isComplete && buffer.isEmpty) {
+        finish()
       } else {
         completion()
       }
@@ -2033,12 +2031,12 @@ private final class LocalSubscriptionProxyConnectionHandler: @unchecked Sendable
     connection.send(content: data, completion: .contentProcessed { [weak self] error in
       guard let self else { return }
       guard error == nil else {
-        self.finish()
+        finish()
         return
       }
       if closeAfterSending {
-        self.connection.cancel()
-        self.finish()
+        connection.cancel()
+        finish()
       } else {
         completion?()
       }
@@ -2049,10 +2047,10 @@ private final class LocalSubscriptionProxyConnectionHandler: @unchecked Sendable
     connection.send(content: data, completion: .contentProcessed { [weak self] error in
       guard let self else { return }
       guard error == nil else {
-        self.finish()
+        finish()
         return
       }
-      self.queue.asyncAfter(deadline: .now() + .milliseconds(100)) {
+      queue.asyncAfter(deadline: .now() + .milliseconds(100)) {
         self.finish()
       }
     })

--- a/ClashMaxTests/SubscriptionPreflightDiagnosticFormatterTests.swift
+++ b/ClashMaxTests/SubscriptionPreflightDiagnosticFormatterTests.swift
@@ -1,6 +1,6 @@
+@testable import ClashMax
 import Foundation
 import XCTest
-@testable import ClashMax
 
 final class SubscriptionPreflightDiagnosticFormatterTests: XCTestCase {
   // Captured Mihomo `-t` output: info/warn lines, then the real

--- a/ClashMaxTests/SystemProxyControllerTests.swift
+++ b/ClashMaxTests/SystemProxyControllerTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import ClashMax
+import XCTest
 
 final class SystemProxyControllerTests: XCTestCase {
   func testRunScriptUsesXcodeManagedSigningAndVerifyOnlyChecks() throws {
@@ -480,7 +480,7 @@ final class SystemProxyControllerTests: XCTestCase {
 
   func testSystemPingTesterUsesFixedExecutableAndParsesLatency() async throws {
     let runner = RecordingCommandRunner(outputs: [
-      "/sbin/ping -c 1 -W 5000 example.com": "64 bytes from 93.184.216.34: icmp_seq=0 ttl=56 time=12.4 ms"
+      "/sbin/ping -c 1 -W 5000 example.com": "64 bytes from 93.184.216.34: icmp_seq=0 ttl=56 time=12.4 ms",
     ])
     let tester = SystemPingTester(commandRunner: runner)
 
@@ -505,7 +505,7 @@ final class SystemProxyControllerTests: XCTestCase {
 
   func testApplySystemProxyTargetsAllActiveServices() async throws {
     let runner = RecordingCommandRunner(outputs: [
-      "/usr/sbin/networksetup -listallnetworkservices": "An asterisk (*) denotes that a network service is disabled.\nWi-Fi\nThunderbolt Bridge\n"
+      "/usr/sbin/networksetup -listallnetworkservices": "An asterisk (*) denotes that a network service is disabled.\nWi-Fi\nThunderbolt Bridge\n",
     ])
     let controller = SystemProxyController(commandRunner: runner)
 
@@ -527,7 +527,7 @@ final class SystemProxyControllerTests: XCTestCase {
       "/usr/sbin/networksetup -getsecurewebproxy Wi-Fi": "Enabled: No\nServer: 127.0.0.1\nPort: 17890\n",
       // Enabled but not loopback: somebody else's proxy, not a ClashMax leftover.
       "/usr/sbin/networksetup -getsocksfirewallproxy Wi-Fi": "Enabled: Yes\nServer: 10.0.0.2\nPort: 8080\n",
-      "/usr/sbin/networksetup -getproxybypassdomains Wi-Fi": "There aren't any bypass domains set.\n"
+      "/usr/sbin/networksetup -getproxybypassdomains Wi-Fi": "There aren't any bypass domains set.\n",
     ])
     let controller = SystemProxyController(commandRunner: runner)
 
@@ -581,7 +581,7 @@ final class SystemProxyControllerTests: XCTestCase {
            en1 : flags      : 0x5 (IPv4,DNS)
 
       Network interfaces: en0 en1
-      """
+      """,
     ])
     let controller = SystemProxyController(commandRunner: runner)
 
@@ -619,10 +619,10 @@ final class SystemProxyControllerTests: XCTestCase {
         "/usr/sbin/networksetup -getwebproxy Ethernet": "Enabled: No\nServer:\nPort: 0\n",
         "/usr/sbin/networksetup -getsecurewebproxy Ethernet": "Enabled: No\nServer:\nPort: 0\n",
         "/usr/sbin/networksetup -getsocksfirewallproxy Ethernet": "Enabled: No\nServer:\nPort: 0\n",
-        "/usr/sbin/networksetup -getproxybypassdomains Ethernet": "There aren't any bypass domains set.\n"
+        "/usr/sbin/networksetup -getproxybypassdomains Ethernet": "There aren't any bypass domains set.\n",
       ],
       failingCommands: [
-        "/usr/sbin/scutil --nwi"
+        "/usr/sbin/scutil --nwi",
       ]
     )
     let controller = SystemProxyController(commandRunner: runner)
@@ -636,7 +636,7 @@ final class SystemProxyControllerTests: XCTestCase {
 
   func testApplySystemProxyAcceptsCustomBypassDomains() async throws {
     let runner = RecordingCommandRunner(outputs: [
-      "/usr/sbin/networksetup -listallnetworkservices": "Wi-Fi\n"
+      "/usr/sbin/networksetup -listallnetworkservices": "Wi-Fi\n",
     ])
     let controller = SystemProxyController(commandRunner: runner)
 
@@ -648,7 +648,7 @@ final class SystemProxyControllerTests: XCTestCase {
   func testApplySystemDNSCapturesAndRestoresEmptyDNS() async throws {
     let runner = RecordingCommandRunner(outputs: [
       "/usr/sbin/networksetup -listallnetworkservices": "Wi-Fi\n",
-      "/usr/sbin/networksetup -getdnsservers Wi-Fi": "There aren't any DNS Servers set on Wi-Fi.\n"
+      "/usr/sbin/networksetup -getdnsservers Wi-Fi": "There aren't any DNS Servers set on Wi-Fi.\n",
     ])
     let controller = SystemProxyController(commandRunner: runner)
 
@@ -666,7 +666,7 @@ final class SystemProxyControllerTests: XCTestCase {
   func testApplySystemDNSRestoresMultipleOriginalServers() async throws {
     let runner = RecordingCommandRunner(outputs: [
       "/usr/sbin/networksetup -listallnetworkservices": "Wi-Fi\n",
-      "/usr/sbin/networksetup -getdnsservers Wi-Fi": "1.1.1.1\n2606:4700:4700::1111\n"
+      "/usr/sbin/networksetup -getdnsservers Wi-Fi": "1.1.1.1\n2606:4700:4700::1111\n",
     ])
     let controller = SystemProxyController(commandRunner: runner)
 
@@ -695,7 +695,7 @@ final class SystemProxyControllerTests: XCTestCase {
     let defaults = try Self.makeIsolatedDefaults()
     let firstRunner = RecordingCommandRunner(outputs: [
       "/usr/sbin/networksetup -listallnetworkservices": "Wi-Fi\n",
-      "/usr/sbin/networksetup -getdnsservers Wi-Fi": "8.8.8.8\n"
+      "/usr/sbin/networksetup -getdnsservers Wi-Fi": "8.8.8.8\n",
     ])
     let firstController = SystemProxyController(commandRunner: firstRunner, snapshotDefaults: defaults)
 
@@ -721,10 +721,10 @@ final class SystemProxyControllerTests: XCTestCase {
         "/usr/sbin/networksetup -getsecurewebproxy Wi-Fi": "Enabled: No\nServer:\nPort: 0\n",
         "/usr/sbin/networksetup -getsocksfirewallproxy Wi-Fi": "Enabled: No\nServer:\nPort: 0\n",
         "/usr/sbin/networksetup -getproxybypassdomains Wi-Fi": "There aren't any bypass domains set.\n",
-        "/usr/sbin/networksetup -getwebproxy Ethernet": "Enabled: No\nServer:\nPort: 0\n"
+        "/usr/sbin/networksetup -getwebproxy Ethernet": "Enabled: No\nServer:\nPort: 0\n",
       ],
       failingCommands: [
-        "/usr/sbin/networksetup -getsecurewebproxy Ethernet"
+        "/usr/sbin/networksetup -getsecurewebproxy Ethernet",
       ]
     )
     let controller = SystemProxyController(commandRunner: runner)
@@ -749,7 +749,7 @@ final class SystemProxyControllerTests: XCTestCase {
       "/usr/sbin/networksetup -getwebproxy Wi-Fi": "Enabled: No\nServer:\nPort: 0\n",
       "/usr/sbin/networksetup -getsecurewebproxy Wi-Fi": "Enabled: Yes\nServer: other.proxy\nPort: 8080\n",
       "/usr/sbin/networksetup -getsocksfirewallproxy Wi-Fi": "Enabled: Yes\nServer: 127.0.0.1\nPort: 7890\n",
-      "/usr/sbin/networksetup -getproxybypassdomains Wi-Fi": "Exceptions List\nlocalhost\n"
+      "/usr/sbin/networksetup -getproxybypassdomains Wi-Fi": "Exceptions List\nlocalhost\n",
     ])
     let controller = SystemProxyController(commandRunner: runner)
 
@@ -768,7 +768,7 @@ final class SystemProxyControllerTests: XCTestCase {
       "/usr/sbin/networksetup -getwebproxy Wi-Fi": "Enabled: Yes\nServer: myhost.lan\nPort: 7890\n",
       "/usr/sbin/networksetup -getsecurewebproxy Wi-Fi": "Enabled: Yes\nServer: myhost.lan\nPort: 7890\n",
       "/usr/sbin/networksetup -getsocksfirewallproxy Wi-Fi": "Enabled: Yes\nServer: myhost.lan\nPort: 7890\n",
-      "/usr/sbin/networksetup -getproxybypassdomains Wi-Fi": "Exceptions List\nlocalhost\n"
+      "/usr/sbin/networksetup -getproxybypassdomains Wi-Fi": "Exceptions List\nlocalhost\n",
     ])
     let controller = SystemProxyController(commandRunner: runner)
 
@@ -786,10 +786,10 @@ final class SystemProxyControllerTests: XCTestCase {
     let runner = FailingCommandRunner(
       outputs: [
         "/usr/sbin/networksetup -listallnetworkservices": "Wi-Fi\n",
-        "/usr/sbin/networksetup -getwebproxy Wi-Fi": "Enabled: No\nServer:\nPort: 0\n"
+        "/usr/sbin/networksetup -getwebproxy Wi-Fi": "Enabled: No\nServer:\nPort: 0\n",
       ],
       failingCommands: [
-        "/usr/sbin/networksetup -getsecurewebproxy Wi-Fi"
+        "/usr/sbin/networksetup -getsecurewebproxy Wi-Fi",
       ]
     )
     let controller = SystemProxyController(commandRunner: runner)
@@ -809,7 +809,7 @@ final class SystemProxyControllerTests: XCTestCase {
       "/usr/sbin/networksetup -getwebproxy Wi-Fi": "Enabled: No\nServer:\nPort: 0\n",
       "/usr/sbin/networksetup -getsecurewebproxy Wi-Fi": "Enabled: No\nServer:\nPort: 0\n",
       "/usr/sbin/networksetup -getsocksfirewallproxy Wi-Fi": "Enabled: No\nServer:\nPort: 0\n",
-      "/usr/sbin/networksetup -getproxybypassdomains Wi-Fi": "There aren't any bypass domains set.\n"
+      "/usr/sbin/networksetup -getproxybypassdomains Wi-Fi": "There aren't any bypass domains set.\n",
     ])
     let controller = SystemProxyController(commandRunner: runner)
 
@@ -865,7 +865,7 @@ final class SystemProxyControllerTests: XCTestCase {
 
   func testRestoreTurnsProxyStatesOff() async throws {
     let runner = RecordingCommandRunner(outputs: [
-      "/usr/sbin/networksetup -listallnetworkservices": "Wi-Fi\n"
+      "/usr/sbin/networksetup -listallnetworkservices": "Wi-Fi\n",
     ])
     let controller = SystemProxyController(commandRunner: runner)
 
@@ -901,7 +901,7 @@ final class SystemProxyControllerTests: XCTestCase {
       Exceptions List
       corp.internal
       *.corp
-      """
+      """,
     ])
     let controller = SystemProxyController(commandRunner: runner)
 
@@ -922,7 +922,7 @@ final class SystemProxyControllerTests: XCTestCase {
       "/usr/sbin/networksetup -getwebproxy Wi-Fi": "Enabled: No\nServer:\nPort: 0\n",
       "/usr/sbin/networksetup -getsecurewebproxy Wi-Fi": "Enabled: No\nServer:\nPort: 0\n",
       "/usr/sbin/networksetup -getsocksfirewallproxy Wi-Fi": "Enabled: No\nServer:\nPort: 0\n",
-      "/usr/sbin/networksetup -getproxybypassdomains Wi-Fi": "There aren't any bypass domains set.\n"
+      "/usr/sbin/networksetup -getproxybypassdomains Wi-Fi": "There aren't any bypass domains set.\n",
     ])
     let firstController = SystemProxyController(commandRunner: firstRunner, snapshotDefaults: defaults)
 
@@ -933,7 +933,7 @@ final class SystemProxyControllerTests: XCTestCase {
       "/usr/sbin/networksetup -getwebproxy Wi-Fi": "Enabled: No\nServer:\nPort: 0\n",
       "/usr/sbin/networksetup -getsecurewebproxy Wi-Fi": "Enabled: No\nServer:\nPort: 0\n",
       "/usr/sbin/networksetup -getsocksfirewallproxy Wi-Fi": "Enabled: No\nServer:\nPort: 0\n",
-      "/usr/sbin/networksetup -getproxybypassdomains Wi-Fi": "There aren't any bypass domains set.\n"
+      "/usr/sbin/networksetup -getproxybypassdomains Wi-Fi": "There aren't any bypass domains set.\n",
     ])
     let secondController = SystemProxyController(commandRunner: secondRunner, snapshotDefaults: defaults)
 
@@ -961,32 +961,32 @@ final class SystemProxyControllerTests: XCTestCase {
         "Wi-Fi\n",
         "Wi-Fi\n",
         "Wi-Fi\n",
-        "Wi-Fi\n"
+        "Wi-Fi\n",
       ],
       "/usr/sbin/networksetup -getwebproxy Wi-Fi": [
         "Enabled: No\nServer:\nPort: 0\n",
         "Enabled: Yes\nServer: 127.0.0.1\nPort: 7890\n",
         "Enabled: Yes\nServer: 127.0.0.1\nPort: 7890\n",
-        "Enabled: No\nServer:\nPort: 0\n"
+        "Enabled: No\nServer:\nPort: 0\n",
       ],
       "/usr/sbin/networksetup -getsecurewebproxy Wi-Fi": [
         "Enabled: No\nServer:\nPort: 0\n",
         "Enabled: Yes\nServer: 127.0.0.1\nPort: 7890\n",
         "Enabled: Yes\nServer: 127.0.0.1\nPort: 7890\n",
-        "Enabled: No\nServer:\nPort: 0\n"
+        "Enabled: No\nServer:\nPort: 0\n",
       ],
       "/usr/sbin/networksetup -getsocksfirewallproxy Wi-Fi": [
         "Enabled: No\nServer:\nPort: 0\n",
         "Enabled: Yes\nServer: 127.0.0.1\nPort: 7890\n",
         "Enabled: Yes\nServer: 127.0.0.1\nPort: 7890\n",
-        "Enabled: No\nServer:\nPort: 0\n"
+        "Enabled: No\nServer:\nPort: 0\n",
       ],
       "/usr/sbin/networksetup -getproxybypassdomains Wi-Fi": [
         "There aren't any bypass domains set.\n",
         "Exceptions List\n\(SystemProxySettings.defaultBypassDomains.joined(separator: "\n"))\n",
         "Exceptions List\n\(SystemProxySettings.defaultBypassDomains.joined(separator: "\n"))\n",
-        "There aren't any bypass domains set.\n"
-      ]
+        "There aren't any bypass domains set.\n",
+      ],
     ])
     let controller = SystemProxyController(commandRunner: runner, snapshotDefaults: defaults)
 
@@ -1019,11 +1019,11 @@ final class SystemProxyControllerTests: XCTestCase {
         "Enabled: Yes\nServer: 127.0.0.1\nPort: 17890\n",
         "Enabled: Yes\nServer: 127.0.0.1\nPort: 17890\n",
         "Enabled: No\nServer:\nPort: 0\n",
-        "Enabled: No\nServer:\nPort: 0\n"
+        "Enabled: No\nServer:\nPort: 0\n",
       ],
       "/usr/sbin/networksetup -getsecurewebproxy Wi-Fi": Array(repeating: "Enabled: No\nServer:\nPort: 0\n", count: 6),
       "/usr/sbin/networksetup -getsocksfirewallproxy Wi-Fi": Array(repeating: "Enabled: No\nServer:\nPort: 0\n", count: 6),
-      "/usr/sbin/networksetup -getproxybypassdomains Wi-Fi": Array(repeating: "There aren't any bypass domains set.\n", count: 6)
+      "/usr/sbin/networksetup -getproxybypassdomains Wi-Fi": Array(repeating: "There aren't any bypass domains set.\n", count: 6),
     ])
     let controller = SystemProxyController(commandRunner: runner, snapshotDefaults: defaults)
     let coordinator = SystemProxyCoordinator(controller: controller, defaults: defaults)
@@ -1046,28 +1046,28 @@ final class SystemProxyControllerTests: XCTestCase {
         "Wi-Fi\n",
         "Wi-Fi\n",
         "Wi-Fi\n",
-        "Wi-Fi\n"
+        "Wi-Fi\n",
       ],
       "/usr/sbin/networksetup -getwebproxy Wi-Fi": [
         "Enabled: Yes\nServer: myhost.lan\nPort: 7890\n",
         "Enabled: Yes\nServer: myhost.lan\nPort: 7890\n",
-        "Enabled: No\nServer:\nPort: 0\n"
+        "Enabled: No\nServer:\nPort: 0\n",
       ],
       "/usr/sbin/networksetup -getsecurewebproxy Wi-Fi": [
         "Enabled: No\nServer:\nPort: 0\n",
         "Enabled: No\nServer:\nPort: 0\n",
-        "Enabled: No\nServer:\nPort: 0\n"
+        "Enabled: No\nServer:\nPort: 0\n",
       ],
       "/usr/sbin/networksetup -getsocksfirewallproxy Wi-Fi": [
         "Enabled: No\nServer:\nPort: 0\n",
         "Enabled: No\nServer:\nPort: 0\n",
-        "Enabled: No\nServer:\nPort: 0\n"
+        "Enabled: No\nServer:\nPort: 0\n",
       ],
       "/usr/sbin/networksetup -getproxybypassdomains Wi-Fi": [
         "There aren't any bypass domains set.\n",
         "There aren't any bypass domains set.\n",
-        "There aren't any bypass domains set.\n"
-      ]
+        "There aren't any bypass domains set.\n",
+      ],
     ])
     let controller = SystemProxyController(commandRunner: runner)
 
@@ -1082,7 +1082,7 @@ final class SystemProxyControllerTests: XCTestCase {
 
   func testRestoreClearsBypassDomainsWhenNoSnapshotExists() async throws {
     let runner = RecordingCommandRunner(outputs: [
-      "/usr/sbin/networksetup -listallnetworkservices": "Wi-Fi\n"
+      "/usr/sbin/networksetup -listallnetworkservices": "Wi-Fi\n",
     ])
     let controller = SystemProxyController(commandRunner: runner)
 
@@ -1193,7 +1193,8 @@ private func waitForRecordedPID(at url: URL, timeout: TimeInterval = 1) async th
     if let text = try? String(contentsOf: url, encoding: .utf8)
       .trimmingCharacters(in: .whitespacesAndNewlines),
       let pid = pid_t(text),
-      pid > 1 {
+      pid > 1
+    {
       return pid
     }
     try await Task.sleep(nanoseconds: 20_000_000)
@@ -1221,7 +1222,7 @@ private func terminateTestProcessIfNeeded(_ pid: pid_t) {
   guard isProcessAlive(pid) else { return }
   kill(pid, SIGTERM)
   let deadline = Date().addingTimeInterval(1)
-  while Date() < deadline && isProcessAlive(pid) {
+  while Date() < deadline, isProcessAlive(pid) {
     usleep(20_000)
   }
   if isProcessAlive(pid) {

--- a/ClashMaxTests/TestDoubles.swift
+++ b/ClashMaxTests/TestDoubles.swift
@@ -1,6 +1,6 @@
+@testable import ClashMax
 import Foundation
 import XCTest
-@testable import ClashMax
 
 @MainActor
 func XCTAssertThrowsErrorAsync<T>(
@@ -48,7 +48,7 @@ func XCTAssertThrowsCancellationErrorAsync<T>(
 }
 
 final class URLProtocolRecorder: @unchecked Sendable {
-  nonisolated(unsafe) private static var active: URLProtocolRecorder?
+  private nonisolated(unsafe) static var active: URLProtocolRecorder?
   private let lock = NSLock()
   private var recordedRequest: URLRequest?
   private var recordedRequests: [URLRequest] = []

--- a/ClashMaxTests/TrafficChartGeometryTests.swift
+++ b/ClashMaxTests/TrafficChartGeometryTests.swift
@@ -1,6 +1,6 @@
+@testable import ClashMax
 import SwiftUI
 import XCTest
-@testable import ClashMax
 
 @MainActor
 final class TrafficChartGeometryTests: XCTestCase {

--- a/ClashMaxTests/TunRuntimeInspectorTests.swift
+++ b/ClashMaxTests/TunRuntimeInspectorTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import ClashMax
+import XCTest
 
 final class TunRuntimeInspectorTests: XCTestCase {
   func testInspectorReportsPassingDataPlaneChecks() async {
@@ -10,7 +10,7 @@ final class TunRuntimeInspectorTests: XCTestCase {
       "/usr/sbin/netstat -rn": "Destination Gateway Flags Netif\n10/8 link#1 UCS en0\n",
       "/usr/bin/dig +time=2 +tries=1 +short www.gstatic.com A": "198.18.0.42\n",
       "/usr/bin/curl -sS -o /dev/null -w %{http_code} --max-time 5 https://www.gstatic.com/generate_204": "204",
-      "/usr/bin/dig @1.1.1.1 +time=2 +tries=1 +short example.com A": "93.184.216.34\n"
+      "/usr/bin/dig @1.1.1.1 +time=2 +tries=1 +short example.com A": "93.184.216.34\n",
     ])
     let inspector = TunRuntimeInspector(commandRunner: runner)
     let snapshot = await inspector.inspect(configuration(routeExcludes: ["10.0.0.0/8"]))
@@ -35,7 +35,7 @@ final class TunRuntimeInspectorTests: XCTestCase {
       "/usr/sbin/netstat -rn": "Destination Gateway Flags Netif\n",
       "/usr/bin/dig +time=2 +tries=1 +short www.gstatic.com A": "142.250.191.68\n",
       "/usr/bin/curl -sS -o /dev/null -w %{http_code} --max-time 5 https://www.gstatic.com/generate_204": "000",
-      "/usr/bin/dig @1.1.1.1 +time=2 +tries=1 +short example.com A": ""
+      "/usr/bin/dig @1.1.1.1 +time=2 +tries=1 +short example.com A": "",
     ])
     let inspector = TunRuntimeInspector(commandRunner: runner)
     let snapshot = await inspector.inspect(configuration(
@@ -60,7 +60,7 @@ final class TunRuntimeInspectorTests: XCTestCase {
       "/usr/bin/curl -fsS --max-time 2 -H Authorization: Bearer secret http://127.0.0.1:9097/version": #"{"version":"v1.19.24"}"#,
       "/sbin/ifconfig": "utun1024: flags=8051<UP,POINTOPOINT,RUNNING,MULTICAST> mtu 1500\n",
       "/sbin/route -n get 1.1.1.1": "route to: 1.1.1.1\ninterface: utun1024\n",
-      "/usr/bin/dig +time=2 +tries=1 +short www.gstatic.com A": "198.18.0.42\n"
+      "/usr/bin/dig +time=2 +tries=1 +short www.gstatic.com A": "198.18.0.42\n",
     ])
     let inspector = TunRuntimeInspector(commandRunner: runner)
     let snapshot = await inspector.inspect(configuration(includeExternal: false))
@@ -79,7 +79,7 @@ final class TunRuntimeInspectorTests: XCTestCase {
         "/sbin/route -n get 1.1.1.1": "route to: 1.1.1.1\ninterface: utun1024\n",
         "/usr/bin/dig +time=2 +tries=1 +short www.gstatic.com A": "198.18.0.42\n",
         "/usr/bin/curl -sS -o /dev/null -w %{http_code} --max-time 5 https://www.gstatic.com/generate_204": "\(status)",
-        "/usr/bin/dig @1.1.1.1 +time=2 +tries=1 +short example.com A": "93.184.216.34\n"
+        "/usr/bin/dig @1.1.1.1 +time=2 +tries=1 +short example.com A": "93.184.216.34\n",
       ])
       let inspector = TunRuntimeInspector(commandRunner: runner)
 
@@ -99,7 +99,7 @@ final class TunRuntimeInspectorTests: XCTestCase {
     let runner = RecordingCommandRunner(outputs: [
       "/sbin/ifconfig": "utun1024: flags=8051<UP,POINTOPOINT,RUNNING,MULTICAST> mtu 1500\n",
       "/sbin/route -n get 1.1.1.1": "route to: 1.1.1.1\ninterface: utun1024\n",
-      "/usr/bin/dig +time=2 +tries=1 +short www.gstatic.com A": "198.18.0.42\n"
+      "/usr/bin/dig +time=2 +tries=1 +short www.gstatic.com A": "198.18.0.42\n",
     ])
     let inspector = TunRuntimeInspector(commandRunner: runner)
 
@@ -139,7 +139,7 @@ final class TunRuntimeInspectorTests: XCTestCase {
       default            10.0.0.1           UGScg        utun1024
       192.168.0/24       link#10            UCS          en0
       """,
-      "/usr/bin/dig +time=2 +tries=1 +short www.gstatic.com A": "198.18.0.42\n"
+      "/usr/bin/dig +time=2 +tries=1 +short www.gstatic.com A": "198.18.0.42\n",
     ])
     let inspector = TunRuntimeInspector(commandRunner: runner)
 
@@ -153,7 +153,7 @@ final class TunRuntimeInspectorTests: XCTestCase {
       "/usr/bin/curl -fsS --max-time 2 -H Authorization: Bearer secret http://127.0.0.1:9097/version": #"{"version":"v1.19.24"}"#,
       "/sbin/ifconfig": "utun1024: flags=8051<UP,POINTOPOINT,RUNNING,MULTICAST> mtu 1500\n",
       "/sbin/route -n get 1.1.1.1": "route to: 1.1.1.1\ninterface: utun999\n",
-      "/usr/bin/dig +time=2 +tries=1 +short www.gstatic.com A": "198.18.0.42\n"
+      "/usr/bin/dig +time=2 +tries=1 +short www.gstatic.com A": "198.18.0.42\n",
     ])
     let inspector = TunRuntimeInspector(commandRunner: runner)
 
@@ -172,7 +172,7 @@ final class TunRuntimeInspectorTests: XCTestCase {
       "/usr/bin/curl -fsS --max-time 2 -H Authorization: Bearer secret http://127.0.0.1:9097/version": #"{"version":"v1.19.24"}"#,
       "/sbin/ifconfig": "utun1024: flags=8051<UP,POINTOPOINT,RUNNING,MULTICAST> mtu 1500\n",
       "/usr/sbin/netstat -rn": "Destination Gateway Flags Netif\n0/0 link#1 UCS en0\n",
-      "/usr/bin/dig +time=2 +tries=1 +short www.gstatic.com A": "198.18.0.42\n"
+      "/usr/bin/dig +time=2 +tries=1 +short www.gstatic.com A": "198.18.0.42\n",
     ])
     let inspector = TunRuntimeInspector(commandRunner: runner)
 
@@ -192,7 +192,7 @@ final class TunRuntimeInspectorTests: XCTestCase {
       includeExternal: false,
       systemProxyState: .entries([
         LocalSystemProxyEntry(service: "Wi-Fi", kind: "HTTP", host: "127.0.0.1", port: 17_890),
-        LocalSystemProxyEntry(service: "Wi-Fi", kind: "HTTPS", host: "127.0.0.1", port: 17_890)
+        LocalSystemProxyEntry(service: "Wi-Fi", kind: "HTTPS", host: "127.0.0.1", port: 17_890),
       ]),
       servedLocalProxyPorts: [7890]
     ))
@@ -214,7 +214,7 @@ final class TunRuntimeInspectorTests: XCTestCase {
     let snapshot = await inspector.inspect(configuration(
       includeExternal: false,
       systemProxyState: .entries([
-        LocalSystemProxyEntry(service: "Wi-Fi", kind: "HTTP", host: "127.0.0.1", port: 7890)
+        LocalSystemProxyEntry(service: "Wi-Fi", kind: "HTTP", host: "127.0.0.1", port: 7890),
       ]),
       servedLocalProxyPorts: [7890]
     ))
@@ -316,7 +316,7 @@ final class TunRuntimeInspectorTests: XCTestCase {
       "/sbin/route -n get 1.1.1.1": "route to: 1.1.1.1\ninterface: \(routeInterface)\n",
       "/usr/bin/dig +time=2 +tries=1 +short www.gstatic.com A": "198.18.0.42\n",
       "/usr/bin/curl -sS -o /dev/null -w %{http_code} --max-time 5 https://www.gstatic.com/generate_204": externalTCPOutput,
-      "/usr/bin/dig @1.1.1.1 +time=2 +tries=1 +short example.com A": externalUDPOutput
+      "/usr/bin/dig @1.1.1.1 +time=2 +tries=1 +short example.com A": externalUDPOutput,
     ])
   }
 

--- a/ClashMaxTests/TunnelHelperClientTests.swift
+++ b/ClashMaxTests/TunnelHelperClientTests.swift
@@ -1,7 +1,7 @@
+@testable import ClashMax
 import Foundation
 import ServiceManagement
 import XCTest
-@testable import ClashMax
 
 @MainActor
 final class TunnelHelperClientTests: XCTestCase {
@@ -282,7 +282,7 @@ final class TunnelHelperClientTests: XCTestCase {
         ok: true,
         protocolVersion: ClashMaxHelperProtocolVersion.current,
         helperBuildVersion: "current"
-      ))
+      )),
     ])
     let recordStore = InMemoryHelperRegistrationRecordStore(storedFingerprint: "same")
     let client = TunnelHelperClient(
@@ -308,7 +308,7 @@ final class TunnelHelperClientTests: XCTestCase {
     ))
     let transport = SequencedHelperTransport(statuses: [
       oldResponse,
-      oldResponse
+      oldResponse,
     ])
     let recordStore = InMemoryHelperRegistrationRecordStore(storedFingerprint: "same")
     let client = TunnelHelperClient(
@@ -416,7 +416,7 @@ final class TunnelHelperClientTests: XCTestCase {
         ok: true,
         protocolVersion: ClashMaxHelperProtocolVersion.current,
         helperBuildVersion: "current"
-      ))
+      )),
     ])
     let recordStore = InMemoryHelperRegistrationRecordStore(storedFingerprint: "current")
     let client = TunnelHelperClient(
@@ -444,7 +444,7 @@ final class TunnelHelperClientTests: XCTestCase {
     ))
     let transport = SequencedHelperTransport(statuses: [
       oldResponse,
-      oldResponse
+      oldResponse,
     ])
     let recordStore = InMemoryHelperRegistrationRecordStore(storedFingerprint: "current")
     let client = TunnelHelperClient(
@@ -551,7 +551,7 @@ final class TunnelHelperClientTests: XCTestCase {
       .failure("xpc unavailable"),
       HelperClientResponse(payload: HelperXPCPayload.response(ok: true)),
       .failure("xpc unavailable"),
-      HelperClientResponse(payload: HelperXPCPayload.response(ok: true))
+      HelperClientResponse(payload: HelperXPCPayload.response(ok: true)),
     ])
     let recordStore = InMemoryHelperRegistrationRecordStore(storedFingerprint: "current")
     let client = TunnelHelperClient(
@@ -579,7 +579,7 @@ final class TunnelHelperClientTests: XCTestCase {
       .failure("xpc unavailable"),
       HelperClientResponse(payload: HelperXPCPayload.response(ok: true)),
       .failure("xpc unavailable"),
-      HelperClientResponse(payload: HelperXPCPayload.response(ok: true))
+      HelperClientResponse(payload: HelperXPCPayload.response(ok: true)),
     ])
     let recordStore = InMemoryHelperRegistrationRecordStore(storedFingerprint: "current")
     let client = TunnelHelperClient(
@@ -771,7 +771,7 @@ final class TunnelHelperClientTests: XCTestCase {
       #selector(ClashMaxHelperXPCProtocol.startTunnel(corePath:configPath:workDirectoryPath:secret:withReply:)),
       #selector(ClashMaxHelperXPCProtocol.stopTunnel(withReply:)),
       #selector(ClashMaxHelperXPCProtocol.restartTunnel(corePath:configPath:workDirectoryPath:secret:withReply:)),
-      #selector(ClashMaxHelperXPCProtocol.recentLogs(withReply:))
+      #selector(ClashMaxHelperXPCProtocol.recentLogs(withReply:)),
     ]
 
     for selector in replySelectors {
@@ -787,7 +787,7 @@ final class TunnelHelperClientTests: XCTestCase {
     let interface = ClashMaxHelperXPCInterface.make()
     let selectors = [
       #selector(ClashMaxHelperXPCProtocol.startTunnel(corePath:configPath:workDirectoryPath:secret:withReply:)),
-      #selector(ClashMaxHelperXPCProtocol.restartTunnel(corePath:configPath:workDirectoryPath:secret:withReply:))
+      #selector(ClashMaxHelperXPCProtocol.restartTunnel(corePath:configPath:workDirectoryPath:secret:withReply:)),
     ]
 
     for selector in selectors {
@@ -817,7 +817,7 @@ final class TunnelHelperClientTests: XCTestCase {
   func testContinuationBoxResumesConnectionFailureThatArrivesBeforeAttachWithoutCleanup() async {
     let cases = [
       "pre-attach invalidation",
-      "pre-attach interruption"
+      "pre-attach interruption",
     ]
 
     for expectedMessage in cases {
@@ -948,7 +948,7 @@ private actor ToggleableHelperState {
   let subsequentStatus: HelperClientResponse
 
   init(initialStatus: HelperClientResponse, subsequentStatus: HelperClientResponse) {
-    self.nextStatus = initialStatus
+    nextStatus = initialStatus
     self.subsequentStatus = subsequentStatus
   }
 
@@ -963,7 +963,7 @@ private final class ToggleableHelperTransport: HelperXPCTransport, Sendable {
   private let state: ToggleableHelperState
 
   init(initialStatus: HelperClientResponse, subsequentStatus: HelperClientResponse) {
-    self.state = ToggleableHelperState(initialStatus: initialStatus, subsequentStatus: subsequentStatus)
+    state = ToggleableHelperState(initialStatus: initialStatus, subsequentStatus: subsequentStatus)
   }
 
   func status() async throws -> HelperClientResponse {
@@ -1006,7 +1006,7 @@ private final class SequencedHelperTransport: HelperXPCTransport, Sendable {
   private let state: SequencedHelperState
 
   init(statuses: [HelperClientResponse]) {
-    self.state = SequencedHelperState(statuses: statuses)
+    state = SequencedHelperState(statuses: statuses)
   }
 
   func status() async throws -> HelperClientResponse {

--- a/ClashMaxTests/TunnelHelperValidationTests.swift
+++ b/ClashMaxTests/TunnelHelperValidationTests.swift
@@ -1,6 +1,6 @@
+@testable import ClashMax
 import Darwin
 import XCTest
-@testable import ClashMax
 
 final class TunnelHelperValidationTests: XCTestCase {
   func testBundledCoreRootUsesExecutableURLWhenLaunchDaemonProgramIsRelative() {
@@ -297,7 +297,7 @@ final class TunnelHelperValidationTests: XCTestCase {
       DispatchQueue.global().async {
         startGate.wait()
         responseRecorder.append(Result {
-          (secret, try start(service, fixture: fixture, secret: secret))
+          try (secret, start(service, fixture: fixture, secret: secret))
         })
         done.leave()
       }
@@ -308,7 +308,7 @@ final class TunnelHelperValidationTests: XCTestCase {
 
     XCTAssertEqual(done.wait(timeout: .now() + 5), .success)
     let responses = try responseRecorder.values.map { try $0.get() }
-    let accepted = responses.filter { $0.1.ok }
+    let accepted = responses.filter(\.1.ok)
     let rejected = responses.filter { !$0.1.ok }
 
     XCTAssertEqual(accepted.count, 1)
@@ -389,7 +389,7 @@ final class TunnelHelperValidationTests: XCTestCase {
     service.status { response in
       payload = response
     }
-    let status = HelperClientResponse(payload: try XCTUnwrap(payload))
+    let status = try HelperClientResponse(payload: XCTUnwrap(payload))
 
     XCTAssertFalse(status.running)
     XCTAssertNil(outputHandle.readabilityHandler)
@@ -533,7 +533,7 @@ private func start(_ service: HelperService, fixture: PathFixture, secret: Strin
   ) { response in
     payload = response
   }
-  return HelperClientResponse(payload: try XCTUnwrap(payload))
+  return try HelperClientResponse(payload: XCTUnwrap(payload))
 }
 
 private func restart(_ service: HelperService, fixture: PathFixture, secret: String) throws -> HelperClientResponse {
@@ -546,7 +546,7 @@ private func restart(_ service: HelperService, fixture: PathFixture, secret: Str
   ) { response in
     payload = response
   }
-  return HelperClientResponse(payload: try XCTUnwrap(payload))
+  return try HelperClientResponse(payload: XCTUnwrap(payload))
 }
 
 private func stop(_ service: HelperService) {
@@ -559,7 +559,8 @@ private func waitForLaunchState(fixture: PathFixture, expected: String) throws -
   var lastState = ""
   while Date() < deadline {
     if let state = try? String(contentsOf: stateURL, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines),
-       !state.isEmpty {
+       !state.isEmpty
+    {
       lastState = state
       if state == expected {
         return state
@@ -579,7 +580,7 @@ private func isProcessAlive(_ pid: pid_t) -> Bool {
 
 private func waitForProcessExit(_ process: Process) {
   let deadline = Date().addingTimeInterval(3)
-  while process.isRunning && Date() < deadline {
+  while process.isRunning, Date() < deadline {
     Thread.sleep(forTimeInterval: 0.02)
   }
 }

--- a/ClashMaxTests/WiFiNetworkInfoTests.swift
+++ b/ClashMaxTests/WiFiNetworkInfoTests.swift
@@ -1,6 +1,6 @@
+@testable import ClashMax
 import CoreLocation
 import XCTest
-@testable import ClashMax
 
 /// Issue #26: macOS 14+ withholds `CWInterface.ssid()` from apps without Location Services access,
 /// so ClashMax reported a bare "No Wi-Fi SSID detected." while the Mac was plainly on Wi-Fi.
@@ -42,7 +42,7 @@ final class WiFiNetworkInfoTests: XCTestCase {
       (.notDetermined, .locationAuthorizationNotDetermined, .requestLocationAuthorization),
       (.denied, .locationAuthorizationDenied, .openLocationSettings),
       (.restricted, .locationAuthorizationDenied, .openLocationSettings),
-      (.servicesDisabled, .locationServicesDisabled, .openLocationSettings)
+      (.servicesDisabled, .locationServicesDisabled, .openLocationSettings),
     ]
 
     for (authorization, expectedReason, expectedAction) in cases {

--- a/Shared/BoundedBuffer.swift
+++ b/Shared/BoundedBuffer.swift
@@ -23,4 +23,3 @@ struct BoundedBuffer<Element> {
     }
   }
 }
-

--- a/Shared/HelperProtocol.swift
+++ b/Shared/HelperProtocol.swift
@@ -38,7 +38,7 @@ enum ClashMaxHelperXPCInterface {
       #selector(ClashMaxHelperXPCProtocol.startTunnel(corePath:configPath:workDirectoryPath:secret:withReply:)),
       #selector(ClashMaxHelperXPCProtocol.stopTunnel(withReply:)),
       #selector(ClashMaxHelperXPCProtocol.restartTunnel(corePath:configPath:workDirectoryPath:secret:withReply:)),
-      #selector(ClashMaxHelperXPCProtocol.recentLogs(withReply:))
+      #selector(ClashMaxHelperXPCProtocol.recentLogs(withReply:)),
     ]
 
     for selector in replySelectors {
@@ -47,7 +47,7 @@ enum ClashMaxHelperXPCInterface {
 
     let tunnelRequestSelectors = [
       #selector(ClashMaxHelperXPCProtocol.startTunnel(corePath:configPath:workDirectoryPath:secret:withReply:)),
-      #selector(ClashMaxHelperXPCProtocol.restartTunnel(corePath:configPath:workDirectoryPath:secret:withReply:))
+      #selector(ClashMaxHelperXPCProtocol.restartTunnel(corePath:configPath:workDirectoryPath:secret:withReply:)),
     ]
     for selector in tunnelRequestSelectors {
       for argumentIndex in 0..<4 {
@@ -119,7 +119,7 @@ enum HelperXPCPayload {
       HelperResponseKey.running: running,
       HelperResponseKey.pid: pid,
       HelperResponseKey.code: code,
-      HelperResponseKey.message: message
+      HelperResponseKey.message: message,
     ]
     if let protocolVersion {
       payload[HelperResponseKey.protocolVersion] = protocolVersion
@@ -163,7 +163,7 @@ enum HelperXPCPayload {
   }
 }
 
-struct HelperBundleLocator {
+enum HelperBundleLocator {
   static func bundledCoreRoot(
     executableURL: URL? = Bundle.main.executableURL,
     commandPath: String = CommandLine.arguments.first ?? "",
@@ -312,7 +312,7 @@ struct HelperPathValidator {
   private static let approvedBundledCoreNames: Set<String> = [
     "mihomo",
     "mihomo-darwin-amd64",
-    "mihomo-darwin-arm64"
+    "mihomo-darwin-arm64",
   ]
   // Downloaded cores need a manifest hash or signing requirement before adding any non-bundle root.
 
@@ -393,9 +393,9 @@ struct HelperCodeSignatureInfo: Equatable {
 
 enum HelperBuildConfiguration {
   #if DEBUG
-  static let allowsLocalDevelopmentSignatureFallback = true
+    static let allowsLocalDevelopmentSignatureFallback = true
   #else
-  static let allowsLocalDevelopmentSignatureFallback = false
+    static let allowsLocalDevelopmentSignatureFallback = false
   #endif
 }
 
@@ -794,7 +794,7 @@ final class HelperService: NSObject, ClashMaxHelperXPCProtocol, @unchecked Senda
     process.currentDirectoryURL = paths.workDirectory
     process.environment = ProcessInfo.processInfo.environment.merging([
       "SAFE_PATHS": paths.workDirectory.path,
-      "CLASHMAX_HELPER": "1"
+      "CLASHMAX_HELPER": "1",
     ]) { _, new in new }
     process.standardOutput = pipe
     process.standardError = pipe
@@ -835,7 +835,7 @@ final class HelperService: NSObject, ClashMaxHelperXPCProtocol, @unchecked Senda
 
   private func waitForProcessExit(_ process: Process, timeout: TimeInterval) {
     let deadline = Date().addingTimeInterval(timeout)
-    while process.isRunning && Date() < deadline {
+    while process.isRunning, Date() < deadline {
       Thread.sleep(forTimeInterval: 0.02)
     }
   }

--- a/Shared/NetworkExtensionRuntimeConstants.swift
+++ b/Shared/NetworkExtensionRuntimeConstants.swift
@@ -104,7 +104,7 @@ struct NetworkExtensionRoutingSettings: Codable, Equatable, Sendable {
     "169.254.0.0/16",
     "::1/128",
     "fe80::/10",
-    "fc00::/7"
+    "fc00::/7",
   ]
 
   var excludeLAN: Bool
@@ -269,7 +269,7 @@ struct NetworkExtensionRoutingSettings: Codable, Equatable, Sendable {
   }
 
   static func normalizedCIDRs(_ values: [String]) -> [String] {
-    normalizedRouteExcludeCIDRs(values).filter(Self.isValidCIDR)
+    normalizedRouteExcludeCIDRs(values).filter(isValidCIDR)
   }
 
   static func normalizedRouteExcludeCIDRs(_ values: [String]) -> [String] {

--- a/Shared/SanitizedLineAccumulator.swift
+++ b/Shared/SanitizedLineAccumulator.swift
@@ -12,7 +12,6 @@ import Foundation
 /// Retention is bounded: the pending buffer never holds more than `maximumLineBytes + 1`
 /// bytes, so a producer that emits an endless line cannot grow this into memory pressure.
 struct SanitizedLineAccumulator {
-
   /// Appended to a line that had to be cut short.
   static let truncationMarker = " <truncated>"
 

--- a/Shared/Socks5ConnectRequest.swift
+++ b/Shared/Socks5ConnectRequest.swift
@@ -105,7 +105,7 @@ enum Socks5ConnectRequest {
     switch endpoint.host {
     case let .ipv4(address):
       data.append(0x01)
-      data.append(try bytes(forIPv4Address: address))
+      try data.append(bytes(forIPv4Address: address))
     case let .domain(domain):
       let bytes = Array(domain.utf8)
       guard bytes.count <= 255 else {
@@ -116,7 +116,7 @@ enum Socks5ConnectRequest {
       data.append(contentsOf: bytes)
     case let .ipv6(address):
       data.append(0x04)
-      data.append(try bytes(forIPv6Address: address))
+      try data.append(bytes(forIPv6Address: address))
     }
 
     guard let portValue = UInt16(exactly: endpoint.port) else {
@@ -275,7 +275,8 @@ struct DNSResponseEndpointMapper: Sendable {
   mutating func responseEndpoint(for payload: Data) -> Socks5Endpoint? {
     guard let key = DNSMessageCorrelationKey(payload: payload),
           var endpoints = pendingEndpoints[key],
-          !endpoints.isEmpty else {
+          !endpoints.isEmpty
+    else {
       return nil
     }
     let endpoint = endpoints.removeFirst()

--- a/Shared/StructuredLogPrivacy.swift
+++ b/Shared/StructuredLogPrivacy.swift
@@ -8,7 +8,6 @@ import Foundation
 /// auth headers, and profile file names — while keeping the parts that make a log useful:
 /// schemes, hosts, ports, directory structure, error domains, and error codes.
 enum StructuredLogRedactor {
-
   /// The single replacement token. Every rule reuses it so a second pass over already
   /// redacted text is a no-op, which is what makes redaction idempotent.
   static let placeholder = "<redacted>"
@@ -86,7 +85,7 @@ enum StructuredLogRedactor {
   ) -> NSRegularExpression {
     // Every pattern here is a compile-time literal; a throw would be a programmer error.
     // swiftlint:disable:next force_try
-    return try! NSRegularExpression(pattern: pattern, options: options)
+    try! NSRegularExpression(pattern: pattern, options: options)
   }
 
   // MARK: - Public API

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -76,6 +76,16 @@ Formatting is enforced by [SwiftFormat](https://github.com/nicklockwood/SwiftFor
 The pinned version lives in one place — the `--minversion` line in
 `.swiftformat` — and CI asserts that the version it installs matches it.
 
+The gate requires that exact version, not merely a new enough one. `.swiftformat`
+opts rules *out* with `--disable` instead of listing the set it wants with
+`--rules`, so a rule a later release adds and enables by default would apply here
+too: formatting with a newer build produces a diff that CI, pinned to the older
+one, rejects. `brew install swiftformat` tracks latest, so once Homebrew moves
+past the pin, install the pinned release directly or point `SWIFTFORMAT` at it —
+the script's error message carries the download link. Moving the pin means
+bumping `.swiftformat` and `.github/workflows/ci.yml` together and reformatting
+the tree with the new build in that same commit.
+
 ```bash
 brew install swiftformat
 script/swiftformat_lint.sh          # check the files this change touches

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -70,6 +70,76 @@ Main verification command:
 xcodebuild test -project ClashMax.xcodeproj -scheme ClashMax -destination 'platform=macOS' -derivedDataPath DerivedData CODE_SIGNING_ALLOWED=NO
 ```
 
+### Code Formatting
+
+Formatting is enforced by [SwiftFormat](https://github.com/nicklockwood/SwiftFormat).
+The pinned version lives in one place — the `--minversion` line in
+`.swiftformat` — and CI asserts that the version it installs matches it.
+
+```bash
+brew install swiftformat
+script/swiftformat_lint.sh          # check the files this change touches
+script/swiftformat_lint.sh --fix    # format exactly that set
+script/swiftformat_lint.sh --all --summary   # remaining debt, per rule
+```
+
+Adoption is deliberately two-step. The tree reached ~100k lines of Swift with no
+formatter at all, so a repo-wide gate would have been red on arrival and a
+single reformat commit would have collided with whatever was in flight.
+
+- **Step 1 (in place).** The gate checks only files the change under review
+  touches, so the tree converges as it is edited. A file nobody has touched is
+  allowed to be unformatted. The `hygiene` CI job runs this on every push and
+  pull request, and separately prints the whole-tree violation count without
+  failing on it, so the remaining debt is visible as it shrinks.
+- **Step 2 (later).** One mechanical commit that formats the remainder, taken at
+  a quiet point with nothing else in flight, and skipped afterwards with
+  `git blame --ignore-rev`. It is *not* a whitespace-only diff — `trailingCommas`,
+  `hoistTry`, `redundantSelf` and `sortImports` move tokens, and `git diff -w`
+  only shrinks it by a tenth — so review it by confirming the formatter is
+  idempotent and the suite is green, not by reading every line:
+
+  ```bash
+  git status --porcelain          # must be empty; this commit carries nothing else
+  script/swiftformat_lint.sh --all --fix
+  xcodebuild test -project ClashMax.xcodeproj -scheme ClashMax -destination 'platform=macOS' -derivedDataPath DerivedData CODE_SIGNING_ALLOWED=NO
+  script/localization_gate.sh     # multiline literals move; the keys must not
+  git commit -am "Format the tree with SwiftFormat"
+  git rev-parse HEAD >> .git-blame-ignore-revs
+  git config blame.ignoreRevsFile .git-blame-ignore-revs
+  ```
+
+  Build it, do not just lint it. `--lint` clean does not mean it compiles:
+  `redundantSelf` strips `self.` from inside `os.Logger` interpolations, where
+  the compiler requires it because the interpolation appenders are `@escaping`
+  autoclosures. That is what `--self-required` in `.swiftformat` is for, and it
+  was found by building, not by linting.
+
+  The localization gate is not optional either: `String(localized:)` multiline
+  literals get re-indented, and a literal whose *value* changed would silently
+  orphan its catalog key.
+
+`.swiftformat` is not the SwiftFormat defaults. Two things shaped it:
+
+- Options describe the style the codebase already had, measured rather than
+  guessed — 2-space indent (298 offending lines, against 86,990 at 4), unspaced
+  ranges (`0..<n`, 361 against 19), lowercase hex, and preserved digit grouping.
+  Adopting the formatter is a normalization pass, not a restyle.
+- Disabled rules follow one line: the formatter normalizes mechanical syntax
+  (whitespace, indentation, ordering, redundant tokens, trailing commas) and
+  does not restructure or delete code someone wrote deliberately. That rules out
+  rewriting `if`/`else` assignments into `if` expressions, expanding one-line
+  bodies such as `var id: String { rawValue }`, promoting explanatory comments to
+  `///`, deleting hand-written memberwise initializers, removing SwiftUI `Group`
+  wrappers (which changes view identity), and rewriting force-unwraps in tests.
+  Each disabled rule carries its reason in the file.
+
+`project.yml` sets `indentWidth: 2` / `tabWidth: 2` / `usesTabs: false`, so the
+generated project tells Xcode's editor the same thing `.swiftformat` tells the
+formatter and code typed in Xcode is born formatted. Those land on the project's
+main group rather than on any build setting, so they do not move the semantic
+snapshot `script/guarded_xcodebuild.sh` compares against.
+
 Localization release gate:
 
 ```bash

--- a/project.yml
+++ b/project.yml
@@ -1,6 +1,11 @@
 name: ClashMax
 options:
   bundleIdPrefix: io.github.clashmax
+  # Match .swiftformat's --indent 2, so code typed in Xcode is born
+  # formatted instead of failing script/swiftformat_lint.sh on save.
+  indentWidth: 2
+  tabWidth: 2
+  usesTabs: false
   developmentLanguage: en
   useBaseInternationalization: false
   fileTypes:

--- a/script/swiftformat_lint.sh
+++ b/script/swiftformat_lint.sh
@@ -63,6 +63,13 @@ cd "$ROOT_DIR"
 # reformats different lines and CI disagrees with the machine the change was
 # written on. .swiftformat carries the pinned version as --minversion, which is
 # also what the CI install step downloads, so this is the one place it lives.
+#
+# The match is exact, in both directions. A newer build is not "good enough"
+# here: .swiftformat opts rules *out* with --disable rather than listing the set
+# it wants with --rules, so a rule that a later release adds and enables by
+# default applies to this repo too. Formatting with it produces a diff that CI,
+# which downloads exactly the pinned version, then rejects -- which is the
+# disagreement this check exists to prevent.
 # ---------------------------------------------------------------------------
 
 SWIFTFORMAT="${SWIFTFORMAT:-swiftformat}"
@@ -78,15 +85,22 @@ EOF
   exit 2
 fi
 
-MIN_VERSION="$(sed -n 's/^--minversion[[:space:]]\{1,\}//p' "$CONFIG" | tr -d '[:space:]')"
-HAVE_VERSION="$("$SWIFTFORMAT" --version)"
-if [ -n "$MIN_VERSION" ]; then
-  oldest="$(printf '%s\n%s\n' "$MIN_VERSION" "$HAVE_VERSION" | sort -V | head -1)"
-  if [ "$oldest" != "$MIN_VERSION" ]; then
-    printf 'swiftformat %s is older than the pinned %s; run `brew upgrade swiftformat`.\n' \
-      "$HAVE_VERSION" "$MIN_VERSION" >&2
-    exit 2
-  fi
+PINNED_VERSION="$(sed -n 's/^--minversion[[:space:]]\{1,\}//p' "$CONFIG" | tr -d '[:space:]')"
+HAVE_VERSION="$("$SWIFTFORMAT" --version | tr -d '[:space:]')"
+if [ -n "$PINNED_VERSION" ] && [ "$HAVE_VERSION" != "$PINNED_VERSION" ]; then
+  cat >&2 <<EOF
+swiftformat $HAVE_VERSION is installed; this repository is pinned to $PINNED_VERSION.
+
+Install the pinned build:
+
+  https://github.com/nicklockwood/SwiftFormat/releases/tag/$PINNED_VERSION
+
+or point SWIFTFORMAT at a $PINNED_VERSION binary. If the intent is to move the
+pin, bump --minversion in .swiftformat together with SWIFTFORMAT_VERSION and
+SWIFTFORMAT_LINUX_SHA256 in .github/workflows/ci.yml; CI asserts the two agree,
+and the whole tree has to be reformatted with the new build in that same commit.
+EOF
+  exit 2
 fi
 
 # ---------------------------------------------------------------------------

--- a/script/swiftformat_lint.sh
+++ b/script/swiftformat_lint.sh
@@ -1,0 +1,238 @@
+#!/bin/sh
+# SwiftFormat gate, scoped to the files a change already touches.
+#
+# ~100k lines of Swift written across many sessions had no formatter at all, so
+# style consistency was maintained by hand. Reformatting everything in one go
+# would bury real changes under thousands of whitespace lines and collide with
+# any work in flight, so adoption is two-step:
+#
+#   1. this gate, which only inspects files the change under review touches, so
+#      the tree converges as it is edited;
+#   2. one separate mechanical commit that formats the remainder, once step 1
+#      has been stable for a while and the working tree is quiet.
+#
+# Because of step 1, a file the change does not touch is allowed to be
+# unformatted. `--all` reports the whole tree if you want to see the remaining
+# debt; CI prints that number too, but never fails on it.
+#
+# usage: swiftformat_lint.sh [options]
+#   --all                lint every Swift source file, not just changed ones
+#   --fix                format the selected files in place instead of linting
+#   --base REF           compare against REF instead of the auto-detected base
+#   --summary            print only the per-rule violation tally
+#   -h, --help           show this help
+#
+# environment:
+#   SWIFTFORMAT          path to the swiftformat binary (default: from PATH)
+#   SWIFTFORMAT_LINT_BASE  same as --base
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+CONFIG="$ROOT_DIR/.swiftformat"
+
+# Every Swift file the project builds. Kept in sync with `sources:` in project.yml.
+SOURCE_DIRS="ClashMax ClashMaxTests Shared ClashMaxHelper ClashMaxNetworkExtension"
+
+MODE="changed"
+ACTION="lint"
+BASE="${SWIFTFORMAT_LINT_BASE:-}"
+# Below this many violations, list them individually; above it, the per-rule
+# tally is the only readable form. --summary forces the tally.
+TALLY_THRESHOLD=50
+FORCE_SUMMARY=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --all) MODE="all"; shift ;;
+    --fix) ACTION="fix"; shift ;;
+    --base) BASE="$2"; shift 2 ;;
+    --summary) FORCE_SUMMARY=1; TALLY_THRESHOLD=0; shift ;;
+    -h|--help) sed -n '/^# usage:/,/^set -eu/{/^set -eu/d;s/^# \{0,1\}//;p;}' "$0"; exit 0 ;;
+    *) printf 'unknown option: %s\n' "$1" >&2; exit 2 ;;
+  esac
+done
+
+cd "$ROOT_DIR"
+[ -f "$CONFIG" ] || { printf 'no .swiftformat at %s\n' "$CONFIG" >&2; exit 2; }
+
+# ---------------------------------------------------------------------------
+# Binary and version
+#
+# A formatter is only a gate if everyone runs the same one: a different build
+# reformats different lines and CI disagrees with the machine the change was
+# written on. .swiftformat carries the pinned version as --minversion, which is
+# also what the CI install step downloads, so this is the one place it lives.
+# ---------------------------------------------------------------------------
+
+SWIFTFORMAT="${SWIFTFORMAT:-swiftformat}"
+if ! command -v "$SWIFTFORMAT" >/dev/null 2>&1; then
+  cat >&2 <<'EOF'
+swiftformat not found.
+
+  brew install swiftformat
+
+or point SWIFTFORMAT at a binary. The pinned version is the --minversion line
+in .swiftformat.
+EOF
+  exit 2
+fi
+
+MIN_VERSION="$(sed -n 's/^--minversion[[:space:]]\{1,\}//p' "$CONFIG" | tr -d '[:space:]')"
+HAVE_VERSION="$("$SWIFTFORMAT" --version)"
+if [ -n "$MIN_VERSION" ]; then
+  oldest="$(printf '%s\n%s\n' "$MIN_VERSION" "$HAVE_VERSION" | sort -V | head -1)"
+  if [ "$oldest" != "$MIN_VERSION" ]; then
+    printf 'swiftformat %s is older than the pinned %s; run `brew upgrade swiftformat`.\n' \
+      "$HAVE_VERSION" "$MIN_VERSION" >&2
+    exit 2
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# File selection
+# ---------------------------------------------------------------------------
+
+resolve_base() {
+  # Explicit wins. github.event.before is all-zeros on a force push or a branch's
+  # first push, so it is validated rather than trusted.
+  if [ -n "$BASE" ] && git rev-parse --verify --quiet "$BASE^{commit}" >/dev/null; then
+    printf '%s' "$BASE"
+    return 0
+  fi
+
+  # Pull requests: the base branch, fetched on demand because a shallow checkout
+  # may not have it.
+  if [ -n "${GITHUB_BASE_REF:-}" ]; then
+    if ! git rev-parse --verify --quiet "origin/$GITHUB_BASE_REF^{commit}" >/dev/null; then
+      git fetch --no-tags --quiet origin "$GITHUB_BASE_REF" 2>/dev/null || true
+    fi
+    if git rev-parse --verify --quiet "origin/$GITHUB_BASE_REF^{commit}" >/dev/null; then
+      printf 'origin/%s' "$GITHUB_BASE_REF"
+      return 0
+    fi
+  fi
+
+  # Local branch work: whatever master the machine already has.
+  for candidate in origin/master master; do
+    if git rev-parse --verify --quiet "$candidate^{commit}" >/dev/null &&
+       [ "$(git rev-parse "$candidate")" != "$(git rev-parse HEAD)" ]; then
+      printf '%s' "$candidate"
+      return 0
+    fi
+  done
+
+  # Nothing left to compare against: HEAD is already the branch everything
+  # merges into. Deliberately not HEAD~1 -- on an up-to-date master that would
+  # blame the previous commit's files for work this change never touched.
+  return 1
+}
+
+# Paths that are Swift but not ours: the SPM checkouts under DerivedData, and
+# any scratch worktree. Mirrors --exclude in .swiftformat.
+drop_non_sources() {
+  grep -v -e '^DerivedData' -e '^\.build/' -e '^\.worktrees/' || true
+}
+
+if [ "$MODE" = "all" ]; then
+  SCOPE_LABEL="every Swift file"
+  FILES="$(
+    for d in $SOURCE_DIRS; do git ls-files -- "$d"; done | grep '\.swift$' | drop_non_sources | sort -u
+  )"
+else
+  # A missing base is not fatal: uncommitted and untracked work is still worth
+  # checking, and it is the case that matters most before a commit exists.
+  BASE_REF="$(resolve_base || true)"
+  if [ -n "$BASE_REF" ]; then
+    SCOPE_LABEL="changed since $BASE_REF, plus uncommitted work"
+  else
+    SCOPE_LABEL="uncommitted work only; HEAD has nothing above its base"
+  fi
+  # `if` rather than `&&`: under `set -e` a short-circuited `&&` list would kill
+  # the subshell and silently drop the sources listed after it.
+  FILES="$(
+    {
+      if [ -n "$BASE_REF" ]; then
+        git diff --name-only --diff-filter=ACMR "$BASE_REF...HEAD"
+      fi
+      if git rev-parse --verify --quiet HEAD >/dev/null; then
+        git diff --name-only --diff-filter=ACMR HEAD
+      fi
+      git ls-files --others --exclude-standard
+    } | grep '\.swift$' | drop_non_sources | sort -u
+  )"
+fi
+
+# Split on newlines only, so a path with a space in it survives, and drop the
+# entries that are in the diff but not on disk (deleted, or renamed away).
+set --
+old_ifs="$IFS"
+IFS='
+'
+# shellcheck disable=SC2086
+for f in $FILES; do
+  if [ -f "$f" ]; then
+    set -- "$@" "$f"
+  fi
+done
+IFS="$old_ifs"
+
+if [ "$#" -eq 0 ]; then
+  printf 'no Swift files to check (%s).\n' "$SCOPE_LABEL"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+
+if [ "$ACTION" = "fix" ]; then
+  printf 'Formatting %d Swift file(s) (%s).\n' "$#" "$SCOPE_LABEL"
+  "$SWIFTFORMAT" --quiet "$@"
+  exit 0
+fi
+
+printf 'Checking %d Swift file(s) (%s).\n' "$#" "$SCOPE_LABEL"
+
+if [ "$FORCE_SUMMARY" -eq 0 ] && [ -n "${GITHUB_ACTIONS:-}" ]; then
+  # Turns every violation into a file/line annotation, so a red run points at the
+  # code in the diff view instead of at a summary line buried in the log.
+  # Rewritten on the way out: GitHub only attaches an annotation to the diff when
+  # the path is repo-relative, and the reporter emits warnings even though this
+  # step is what fails the job.
+  status=0
+  output="$("$SWIFTFORMAT" --lint --quiet --reporter github-actions-log "$@" 2>&1)" || status=$?
+  printf '%s\n' "$output" | sed -e "s|$ROOT_DIR/||g" -e 's|^::warning |::error |'
+else
+  # Compiler-style `path:line:col: error: (rule) reason`, minus the progress
+  # chatter, with paths made repo-relative so they stay clickable.
+  status=0
+  output="$("$SWIFTFORMAT" --lint "$@" 2>&1)" || status=$?
+  diagnostics="$(printf '%s\n' "$output" | grep ': error: (' | sed "s|$ROOT_DIR/||" || true)"
+  count="$(printf '%s' "$diagnostics" | grep -c . || true)"
+  if [ "$count" -gt "$TALLY_THRESHOLD" ]; then
+    # A whole-tree run prints thousands of lines nobody reads; the per-rule tally
+    # is what tells you what the remaining debt actually consists of.
+    printf '%s\n' "$diagnostics" | sed -n 's/^.*: error: (\([A-Za-z]*\)).*/\1/p' | sort | uniq -c | sort -rn
+    printf '%s violations in total.\n' "$count"
+  elif [ "$count" -gt 0 ]; then
+    printf '%s\n' "$diagnostics"
+  fi
+fi
+
+if [ "$status" -eq 0 ]; then
+  echo "SwiftFormat: clean."
+  exit 0
+fi
+
+cat >&2 <<EOF
+
+SwiftFormat found unformatted code in the files above.
+
+  script/swiftformat_lint.sh --fix
+
+formats exactly the same set. Only files this change touches are checked, so a
+fix here should be small; if it is not, the file was simply never formatted
+before and this is the pass that does it.
+EOF
+exit 1


### PR DESCRIPTION
Adopts SwiftFormat, in the two steps that were planned so the mechanical churn never
lands on top of real work.

The tree is ~100k lines of Swift written across many sessions with no formatter at
all, so style consistency was maintained by hand. A repo-wide gate would have been
red on arrival, and one giant reformat would have collided with anything in flight.

### The three commits

| commit | what it is |
|---|---|
| `dd8394c` | `.swiftformat`, `script/swiftformat_lint.sh`, the CI steps, and the docs. The gate inspects **only the files a change touches**, so the tree converges as it is edited. |
| `d2fd50a` | The whole-tree pass. 107 files, purely mechanical, `--lint` clean afterwards. |
| `c19a3c7` | `.git-blame-ignore-revs` so `d2fd50a` does not show up in `git blame`. |

Whole-tree debt: **2107 violations → 0**.

Rule mix in the format commit: `trailingCommas` 518, `hoistTry` 424, `redundantSelf`
312, `indent` 252, `wrapMultilineStatementBraces` 98, `sortImports` 94, `hoistAwait` 80.

### Two real defects the formatter would have shipped

Both were found by building and by reading the diff, not by linting — and both are now
pinned in `.swiftformat` with the reason written next to them.

**1. `redundantSelf` produced code that does not compile.** `os.Logger` builds its
message from `@escaping` autoclosures, so a property inside a `\(…)` interpolation is
captured in an escaping closure and Swift *requires* the explicit `self.`. SwiftFormat
does not model that and stripped it:

```
ClashMaxNetworkExtension/TransparentProxyProvider.swift:81:56: error: reference to
property 'socksHost' in closure requires explicit use of 'self' to make capture
semantics explicit
```

`swiftformat --lint` was **clean** on that. Fixed with
`--self-required log,trace,debug,info,notice,warning,error,critical,fault`.

**2. Three rules were editing declarations, not formatting.** `redundantThrows` /
`redundantAsync` stripped `throws`/`async` from 53 sites — 51 of them XCTest methods,
where `throws` is deliberate headroom so the next `try XCTUnwrap` does not have to touch
the signature. `opaqueGenericParameters` rewrote `<T>` into `some Any`. All three
disabled.

### Verification

- **Full suite green on the formatted tree** — locally 1128 XCTest passed / 0 failed /
  1 skipped, plus 5 Swift Testing passed, `** TEST SUCCEEDED **`. CI on this PR: 1124
  passed / 0 failed / 6 skipped. The 5 extra CI skips are the ones a fresh clone always
  skips (no bundled Mihomo core, no workstation release runbook), so the two runs cover
  the same set.
- **No test was lost** — 1122 XCTest method names identical before and after, 5 `@Test`
  attributes identical, no `XCTSkip` added.
- **Localization-safe** — 0 of 14866 Swift string-literal *values* changed (multiline
  literals strip by the closing delimiter's indent, so re-indenting them is
  value-preserving). `Resources/Localizable.xcstrings` untouched;
  `script/localization_new_key_gate.sh` green.
- **Idempotent** — a second `--fix` pass is a no-op.

### Notes for review

Do **not** read this line by line. It is not a whitespace-only diff — `trailingCommas`,
`hoistTry`, `redundantSelf` and `sortImports` move tokens, and `git diff -w` only shrinks
it by about a tenth. The way to review it is the evidence above: the formatter is
idempotent, the suite is green, and no declaration or literal changed.

`project.yml` also gains `indentWidth: 2` / `tabWidth: 2` / `usesTabs: false` so code
typed in Xcode is born formatted. Those land on the generated project's main `PBXGroup`,
which the semantic project guard does not read — verified by diffing snapshots.

After merging, run once locally so `git blame` skips the pass:

```bash
git config blame.ignoreRevsFile .git-blame-ignore-revs
```

### Review follow-ups

Two review-bot findings were real and are fixed in `9b39042`:

- **The version check only enforced a minimum.** `.swiftformat` opts rules out with
  `--disable` rather than listing them with `--rules`, so a rule a later release adds
  and enables by default applies here too — a workstation on a newer build would
  format a diff that CI, pinned to 0.62.1, rejects. Now an exact match in both
  directions, with an error that links the pinned release. This also removed the
  `sort -V` call two bots flagged as macOS-incompatible; that claim is wrong (Apple's
  `/usr/bin/sort` 2.3-Apple supports `-V`, checked under a clean `PATH`), but the
  construct is gone regardless.
- **`.git-blame-ignore-revs` depends on the merge method.** The entry works today, but
  squash and rebase would rewrite the branch and leave the recorded SHA naming a commit
  master never receives, silently doing nothing. Written into the file itself.

**Merge this with a merge commit, not squash**, or the blame entry breaks.

A third defect surfaced from CI's own logs and is fixed in `cf12f43`: the gate passed
`github.event.before` unconditionally, which is empty when a PR is opened but carries
the *previous head* on every later synchronize. Runs after the first therefore checked
only that push's delta rather than everything the PR changes. Now scoped to push events.

### CI on this PR

All three jobs green on the final commit
([run 31760318726](https://github.com/marvinli001/ClashMax/actions/runs/31760318726)).

- **Repo hygiene** — SwiftFormat 0.62.1; gate checked all 107 changed files, clean.
  The never-fails debt step reports `Checking 133 Swift file(s) (every Swift file). SwiftFormat: clean.`
- **Tests and localization gate** — `** TEST SUCCEEDED **`, localization gate green.
- **Release build** — universal bundle layout and the no-Intel-only-binary check both pass.
